### PR TITLE
FEATURE: add job retry for failed jobs, e.g. for API timeouts

### DIFF
--- a/app/jobs/regular/chatbot_reply_job.rb
+++ b/app/jobs/regular/chatbot_reply_job.rb
@@ -2,7 +2,20 @@
 
 # Job is triggered to respond to Message or Post appropriately, checking user's quota.
 class ::Jobs::ChatbotReplyJob < Jobs::Base
-  sidekiq_options retry: false
+  sidekiq_options retry: 0, dead: false
+
+  sidekiq_retries_exhausted do |msg, ex|
+    message_body = I18n.t('chatbot.errors.retries')
+    opts = msg['args'].first.transform_keys(&:to_sym)
+    opts.merge!(message_body: message_body)
+    type = opts[:type]
+    if type == ::DiscourseChatbot::POST
+      reply_creator = ::DiscourseChatbot::PostReplyCreator.new(opts)
+    else
+      reply_creator = ::DiscourseChatbot::MessageReplyCreator.new(opts)
+    end
+    reply_creator.create
+  end
 
   def execute(opts)
     type = opts[:type]
@@ -56,8 +69,8 @@ class ::Jobs::ChatbotReplyJob < Jobs::Base
         bot = ::DiscourseChatbot::OpenAIBot.new
         message_body = bot.ask(opts)
       rescue => e
-        message_body = I18n.t('chatbot.errors.general')
-        Rails.logger.error ("OpenAIBot: There was a problem: #{e}")
+        Rails.logger.error ("OpenAIBot: There was a problem, but will retry til limit: #{e}")
+        fail e
       end
     end
     opts.merge!(message_body: message_body)

--- a/app/jobs/regular/chatbot_reply_job.rb
+++ b/app/jobs/regular/chatbot_reply_job.rb
@@ -2,7 +2,7 @@
 
 # Job is triggered to respond to Message or Post appropriately, checking user's quota.
 class ::Jobs::ChatbotReplyJob < Jobs::Base
-  sidekiq_options retry: 0, dead: false
+  sidekiq_options retry: 5, dead: false
 
   sidekiq_retries_exhausted do |msg, ex|
     message_body = I18n.t('chatbot.errors.retries')

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -29,6 +29,7 @@ en:
       post: "%{username} said %{raw}"
     errors:
       general: "Sorry, I'm not well right now. Lets talk some other time. Meanwhile, please ask the admin to check the logs, thank you!"
+      retries: "I've tried working out a response for you several times, but ultimately failed.  Please contact the admin if this persists, thank you!"
       forbiddeninprivatemessages: "Use in private messages has not been permitted, please contact the admin"
       forbiddenoutsidethesecategories: "Public use of Chatbot has only been permitted in these Categories: "
       forbiddenanycategory: "Public use of Chatbot has not been enabled in any Category, please contact your admin"

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.14
+# version: 0.15
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 


### PR DESCRIPTION
* Open AI API has a tendency to time out at present
* This PR will add a retry limit of 5 tries, after which the job will be dropped completely
* On timeout the issue should be logged
* The user will receive a helpful message if the timeout occurs to the limit of retries.