### PR TITLE
FEATURE: Strip quotes by default from most prompts and only consider normal posts

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,6 +5,7 @@ en:
     chatbot_open_ai_model: "The model to be accessed. More on supported models at <a target='_blank' rel='noopener' href='https://platform.openai.com/docs/models/overview'>OpenAI: Model overview</a>"
     chatbot_reply_job_time_delay: 'Number of seconds before reply job is run. This helps prevent rate limits being hit and discourages spamming.'
     chatbot_max_look_behind: "Maximum number of Posts or Chat Messages bot will consider as prompt for completion, the more the more impressive may be its response, but the more costly the interaction will be."
+    chatbot_strip_quotes: "Determine if quotes are stripped and not sent within prompts (doesn't affect OP)"
     chatbot_permitted_in_private_messages: "Allow Chatbot to interact in Private Messages"
     chatbot_permitted_in_chat: "Allow Chatbot to interact in Chat"
     chatbot_permitted_all_categories: "Allow Chatbot to interact in any Category"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -48,6 +48,9 @@ plugins:
     max: 10
     min: 1
     client: false
+  chatbot_strip_quotes:
+    default: true
+    client: false
   chatbot_open_ai_model:
     client: false
     type: enum

--- a/lib/discourse_chatbot/post/post_evaluation.rb
+++ b/lib/discourse_chatbot/post/post_evaluation.rb
@@ -15,7 +15,7 @@ module ::DiscourseChatbot
       post_contents = post.raw.to_s
 
       # remove the 'quote' blocks
-      post_contents.gsub!(/\[quote.*?\](.*?)\[\/quote\]/m,'')
+      post_contents.gsub!(/\[quote.*?\](.*?)\[\/quote\]/m, '')
 
       bot_username = SiteSetting.chatbot_bot_user
       bot_user = ::User.find_by(username: bot_username)

--- a/lib/discourse_chatbot/post/post_evaluation.rb
+++ b/lib/discourse_chatbot/post/post_evaluation.rb
@@ -15,7 +15,7 @@ module ::DiscourseChatbot
       post_contents = post.raw.to_s
 
       # remove the 'quote' blocks
-      post_contents.gsub!(%r{\[quote.*?\][^\[]+\[/quote\]}, '')
+      post_contents.gsub!(/\[quote.*?\](.*?)\[\/quote\]/m,'')
 
       bot_username = SiteSetting.chatbot_bot_user
       bot_user = ::User.find_by(username: bot_username)

--- a/lib/discourse_chatbot/post/post_prompt_utils.rb
+++ b/lib/discourse_chatbot/post/post_prompt_utils.rb
@@ -16,7 +16,7 @@ module ::DiscourseChatbot
           post_content = p.raw
           post_content.gsub!(/\[quote.*?\](.*?)\[\/quote\]/m, '') if SiteSetting.chatbot_strip_quotes
           role = (p.user_id == bot_user_id ? "assistant" : "user")
-          content = (p.user_id == bot_user_id ? "#{p.raw}" : I18n.t("chatbot.prompt.post", username: p.user.username, raw: p.post_content))
+          content = (p.user_id == bot_user_id ? "#{p.raw}" : I18n.t("chatbot.prompt.post", username: p.user.username, raw: post_content))
           { "role": role , "content": content }
         end
 

--- a/lib/discourse_chatbot/post/post_prompt_utils.rb
+++ b/lib/discourse_chatbot/post/post_prompt_utils.rb
@@ -14,9 +14,10 @@ module ::DiscourseChatbot
 
         messages += post_collection.reverse.map do |p|
           post_content = p.raw
-          post_content.gsub!(/\[quote.*?\](.*?)\[\/quote\]/m,'') if SiteSetting.chatbot_strip_quotes
-          { "role": (p.user_id == bot_user_id ? "assistant" : "user"),
-           "content": (p.user_id == bot_user_id ? "#{p.raw}" : I18n.t("chatbot.prompt.post", username: p.user.username, raw: p.post_content)) }
+          post_content.gsub!(/\[quote.*?\](.*?)\[\/quote\]/m, '') if SiteSetting.chatbot_strip_quotes
+          role = (p.user_id == bot_user_id ? "assistant" : "user")
+          content = (p.user_id == bot_user_id ? "#{p.raw}" : I18n.t("chatbot.prompt.post", username: p.user.username, raw: p.post_content))
+          { "role": role , "content": content }
         end
 
         messages

--- a/plugin.rb
+++ b/plugin.rb
@@ -59,7 +59,7 @@ after_initialize do
   DiscourseEvent.on(:post_created) do |*params|
     post, opts, user = params
 
-    if SiteSetting.chatbot_enabled
+    if SiteSetting.chatbot_enabled && post.post_type == 1
       ::DiscourseChatbot.progress_debug_message("1. trigger")
 
       bot_username = SiteSetting.chatbot_bot_user

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.18
+# version: 0.19
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/post/post_prompt_utils_spec.rb
+++ b/spec/lib/post/post_prompt_utils_spec.rb
@@ -6,11 +6,14 @@ describe ::DiscourseChatbot::PostPromptUtils do
   let(:topic) { Fabricate(:topic) }
   let!(:post_1) { Fabricate(:post, topic: topic) }
   let!(:post_2) { Fabricate(:post, topic: topic) }
-  let!(:post_3) { Fabricate(:post, topic: topic, reply_to_post_number: 1) }
-  let!(:post_4) { Fabricate(:post, topic: topic, reply_to_post_number: 2) }
-  let!(:post_5) { Fabricate(:post, topic: topic) }
-  let!(:post_6) { Fabricate(:post, topic: topic, reply_to_post_number: 3) }
-  let!(:post_7) { Fabricate(:post, topic: topic) }
+  let!(:post_3) { Fabricate(:post, topic: topic, post_type: 4) }
+  let!(:post_4) { Fabricate(:post, topic: topic, reply_to_post_number: 1) }
+  let!(:post_5) { Fabricate(:post, topic: topic, reply_to_post_number: 2) }
+  let!(:post_6) { Fabricate(:post, topic: topic) }
+  let!(:post_7) { Fabricate(:post, topic: topic, post_type: 2) }
+  let!(:post_8) { Fabricate(:post, topic: topic, post_type: 2) }
+  let!(:post_9) { Fabricate(:post, topic: topic, reply_to_post_number: 7) }
+  let!(:post_10) { Fabricate(:post, topic: topic) }
 
   before(:each) do
     SiteSetting.chatbot_enabled = true
@@ -19,18 +22,15 @@ describe ::DiscourseChatbot::PostPromptUtils do
   it "captures the right history when one post contains a reply to the bot" do
     past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_1.id)
     expect(past_posts.count).to equal(1)
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_3.id)
-    expect(past_posts.count).to equal(2)
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_5.id)
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_6.id)
     expect(past_posts.count).to equal(4)
     past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_6.id)
-    expect(past_posts.count).to equal(3)
-
-    post_5.destroy
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_7.id)
     expect(past_posts.count).to equal(4)
-    post_3.destroy
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_7.id)
-    expect(past_posts.count).to equal(3)
+
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_10.id)
+    expect(past_posts.count).to equal(5)
+    post_9.destroy
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_10.id)
+    expect(past_posts.count).to equal(5)
   end
 end


### PR DESCRIPTION
* FEATURE: strips quotes from all Post prompts (bar OP) if setting set (ON by default)
* FIX: Post prompt history will not include moderation action posts
* FIX: bot will not be invoked by any Topic moderation action