### PR TITLE
FIX: everyone group quota handling

### DIFF
--- a/lib/discourse_chatbot/event_evaluation.rb
+++ b/lib/discourse_chatbot/event_evaluation.rb
@@ -11,13 +11,13 @@ module ::DiscourseChatbot
       max_quota = 0
 
       GroupUser.where(user_id: user_id).each do |gu|
-        if SiteSetting.chatbot_high_trust_groups.split('|').include? gu.group_id.to_s || SiteSetting.chatbot_high_trust_groups.split('|').include?("0")
+        if SiteSetting.chatbot_high_trust_groups.split('|').include? gu.group_id.to_s
           max_quota = SiteSetting.chatbot_quota_high_trust if max_quota < SiteSetting.chatbot_quota_high_trust
         end
-        if SiteSetting.chatbot_medium_trust_groups.split('|').include? gu.group_id.to_s || SiteSetting.chatbot_medium_trust_groups.split('|').include?("0")
+        if SiteSetting.chatbot_medium_trust_groups.split('|').include? gu.group_id.to_s
           max_quota = SiteSetting.chatbot_quota_medium_trust if max_quota < SiteSetting.chatbot_quota_medium_trust
         end
-        if SiteSetting.chatbot_low_trust_groups.split('|').include? gu.group_id.to_s || SiteSetting.chatbot_low_trust_groups.split('|').include?("0")
+        if SiteSetting.chatbot_low_trust_groups.split('|').include? gu.group_id.to_s
           max_quota = SiteSetting.chatbot_quota_low_trust if max_quota < SiteSetting.chatbot_quota_low_trust
         end
       end

--- a/lib/discourse_chatbot/event_evaluation.rb
+++ b/lib/discourse_chatbot/event_evaluation.rb
@@ -11,16 +11,21 @@ module ::DiscourseChatbot
       max_quota = 0
 
       GroupUser.where(user_id: user_id).each do |gu|
-        if SiteSetting.chatbot_high_trust_groups.split('|').include? gu.group_id.to_s
+        if SiteSetting.chatbot_high_trust_groups.split('|').include? gu.group_id.to_s || SiteSetting.chatbot_high_trust_groups.split('|').include?("0")
           max_quota = SiteSetting.chatbot_quota_high_trust if max_quota < SiteSetting.chatbot_quota_high_trust
         end
-        if SiteSetting.chatbot_medium_trust_groups.split('|').include? gu.group_id.to_s
+        if SiteSetting.chatbot_medium_trust_groups.split('|').include? gu.group_id.to_s || SiteSetting.chatbot_medium_trust_groups.split('|').include?("0")
           max_quota = SiteSetting.chatbot_quota_medium_trust if max_quota < SiteSetting.chatbot_quota_medium_trust
         end
-        if SiteSetting.chatbot_low_trust_groups.split('|').include? gu.group_id.to_s
+        if SiteSetting.chatbot_low_trust_groups.split('|').include? gu.group_id.to_s || SiteSetting.chatbot_low_trust_groups.split('|').include?("0")
           max_quota = SiteSetting.chatbot_quota_low_trust if max_quota < SiteSetting.chatbot_quota_low_trust
         end
       end
+
+      # deal with 'everyone' group
+      max_quota = SiteSetting.chatbot_quota_high_trust if SiteSetting.chatbot_high_trust_groups.split('|').include?("0") && max_quota < SiteSetting.chatbot_quota_high_trust
+      max_quota = SiteSetting.chatbot_quota_medium_trust if SiteSetting.chatbot_medium_trust_groups.split('|').include?("0") && max_quota < SiteSetting.chatbot_quota_medium_trust
+      max_quota = SiteSetting.chatbot_quota_low_trust if SiteSetting.chatbot_low_trust_groups.split('|').include?("0") && max_quota < SiteSetting.chatbot_quota_low_trust
 
       if current_record = UserCustomField.find_by(user_id: user_id, name: CHATBOT_QUERIES_CUSTOM_FIELD)
         current_queries = current_record.value.to_i + 1

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.20
+# version: 0.21
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/event_evaluation_spec.rb
+++ b/spec/lib/event_evaluation_spec.rb
@@ -18,7 +18,7 @@ describe ::DiscourseChatbot::EventEvaluation do
     SiteSetting.chatbot_medium_trust_groups = "11|12"
     SiteSetting.chatbot_low_trust_groups = "10"
     SiteSetting.chatbot_quota_high_trust = 3
-    SiteSetting.chatbot_quota_medium_trust = 2 
+    SiteSetting.chatbot_quota_medium_trust = 2
     SiteSetting.chatbot_quota_low_trust = 1
     Group.refresh_automatic_groups!(:trust_level_3)
     event = ::DiscourseChatbot::EventEvaluation.new
@@ -31,7 +31,7 @@ describe ::DiscourseChatbot::EventEvaluation do
     SiteSetting.chatbot_medium_trust_groups = "11|12"
     SiteSetting.chatbot_low_trust_groups = "10"
     SiteSetting.chatbot_quota_high_trust = 3
-    SiteSetting.chatbot_quota_medium_trust = 2 
+    SiteSetting.chatbot_quota_medium_trust = 2
     SiteSetting.chatbot_quota_low_trust = 1
     Group.refresh_automatic_groups!(:trust_level_3)
     event = ::DiscourseChatbot::EventEvaluation.new
@@ -44,7 +44,7 @@ describe ::DiscourseChatbot::EventEvaluation do
     SiteSetting.chatbot_medium_trust_groups = "11|12"
     SiteSetting.chatbot_low_trust_groups = "0"
     SiteSetting.chatbot_quota_high_trust = 4
-    SiteSetting.chatbot_quota_medium_trust = 3 
+    SiteSetting.chatbot_quota_medium_trust = 3
     SiteSetting.chatbot_quota_low_trust = 2
     event = ::DiscourseChatbot::EventEvaluation.new
     expect(event.over_quota(normal_user.id)).to equal(false)
@@ -56,7 +56,7 @@ describe ::DiscourseChatbot::EventEvaluation do
     SiteSetting.chatbot_medium_trust_groups = "11|12"
     SiteSetting.chatbot_low_trust_groups = "0"
     SiteSetting.chatbot_quota_high_trust = 4
-    SiteSetting.chatbot_quota_medium_trust = 3 
+    SiteSetting.chatbot_quota_medium_trust = 3
     SiteSetting.chatbot_quota_low_trust = 2
     event = ::DiscourseChatbot::EventEvaluation.new
     expect(event.over_quota(normal_user.id)).to equal(true)
@@ -68,7 +68,7 @@ describe ::DiscourseChatbot::EventEvaluation do
     SiteSetting.chatbot_medium_trust_groups = ""
     SiteSetting.chatbot_low_trust_groups = ""
     SiteSetting.chatbot_quota_high_trust = 4
-    SiteSetting.chatbot_quota_medium_trust = 3 
+    SiteSetting.chatbot_quota_medium_trust = 3
     SiteSetting.chatbot_quota_low_trust = 2
     Group.refresh_automatic_groups!(:staff)
     event = ::DiscourseChatbot::EventEvaluation.new
@@ -81,7 +81,7 @@ describe ::DiscourseChatbot::EventEvaluation do
     SiteSetting.chatbot_medium_trust_groups = ""
     SiteSetting.chatbot_low_trust_groups = ""
     SiteSetting.chatbot_quota_high_trust = 4
-    SiteSetting.chatbot_quota_medium_trust = 3 
+    SiteSetting.chatbot_quota_medium_trust = 3
     SiteSetting.chatbot_quota_low_trust = 2
     Group.refresh_automatic_groups!(:staff)
     event = ::DiscourseChatbot::EventEvaluation.new
@@ -89,5 +89,3 @@ describe ::DiscourseChatbot::EventEvaluation do
   end
 
 end
-
-

--- a/spec/lib/event_evaluation_spec.rb
+++ b/spec/lib/event_evaluation_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+require_relative '../plugin_helper'
+
+CHATBOT_QUERIES_CUSTOM_FIELD = "chatbot_queries"
+
+describe ::DiscourseChatbot::EventEvaluation do
+  let(:normal_user) { Fabricate(:user) }
+  let(:high_trust_user) { Fabricate(:user, trust_level: TrustLevel[3]) }
+  let(:moderator) { Fabricate(:moderator) }
+
+  before(:each) do
+    SiteSetting.chatbot_enabled = true
+  end
+
+  it "returns the correct quota decision if user is in high trust group and is within quota" do
+    UserCustomField.create!(user_id: high_trust_user.id, name: CHATBOT_QUERIES_CUSTOM_FIELD, value: 1)
+    SiteSetting.chatbot_high_trust_groups = "13|14"
+    SiteSetting.chatbot_medium_trust_groups = "11|12"
+    SiteSetting.chatbot_low_trust_groups = "10"
+    SiteSetting.chatbot_quota_high_trust = 3
+    SiteSetting.chatbot_quota_medium_trust = 2 
+    SiteSetting.chatbot_quota_low_trust = 1
+    Group.refresh_automatic_groups!(:trust_level_3)
+    event = ::DiscourseChatbot::EventEvaluation.new
+    expect(event.over_quota(high_trust_user.id)).to equal(false)
+  end
+
+  it "returns the correct quota decision if user is in high trust group and user is outside of quota" do
+    UserCustomField.create!(user_id: high_trust_user.id, name: CHATBOT_QUERIES_CUSTOM_FIELD, value: 3)
+    SiteSetting.chatbot_high_trust_groups = "13|14"
+    SiteSetting.chatbot_medium_trust_groups = "11|12"
+    SiteSetting.chatbot_low_trust_groups = "10"
+    SiteSetting.chatbot_quota_high_trust = 3
+    SiteSetting.chatbot_quota_medium_trust = 2 
+    SiteSetting.chatbot_quota_low_trust = 1
+    Group.refresh_automatic_groups!(:trust_level_3)
+    event = ::DiscourseChatbot::EventEvaluation.new
+    expect(event.over_quota(high_trust_user.id)).to equal(true)
+  end
+
+  it "returns the correct quota decision if 'everyone' group exists in a chatbot trust level and user has not reached their quota" do
+    UserCustomField.create!(user_id: normal_user.id, name: CHATBOT_QUERIES_CUSTOM_FIELD, value: 1)
+    SiteSetting.chatbot_high_trust_groups = "13|14"
+    SiteSetting.chatbot_medium_trust_groups = "11|12"
+    SiteSetting.chatbot_low_trust_groups = "0"
+    SiteSetting.chatbot_quota_high_trust = 4
+    SiteSetting.chatbot_quota_medium_trust = 3 
+    SiteSetting.chatbot_quota_low_trust = 2
+    event = ::DiscourseChatbot::EventEvaluation.new
+    expect(event.over_quota(normal_user.id)).to equal(false)
+  end
+
+  it "returns the correct quota decision if 'everyone' group exists in a chatbot trust level and user has reached their quota" do
+    UserCustomField.create!(user_id: normal_user.id, name: CHATBOT_QUERIES_CUSTOM_FIELD, value: 2)
+    SiteSetting.chatbot_high_trust_groups = "13|14"
+    SiteSetting.chatbot_medium_trust_groups = "11|12"
+    SiteSetting.chatbot_low_trust_groups = "0"
+    SiteSetting.chatbot_quota_high_trust = 4
+    SiteSetting.chatbot_quota_medium_trust = 3 
+    SiteSetting.chatbot_quota_low_trust = 2
+    event = ::DiscourseChatbot::EventEvaluation.new
+    expect(event.over_quota(normal_user.id)).to equal(true)
+  end
+
+  it "returns the correct quota decision if staff group exists in a chatbot trust level and user has not reached their quota" do
+    UserCustomField.create!(user_id: moderator.id, name: CHATBOT_QUERIES_CUSTOM_FIELD, value: 1)
+    SiteSetting.chatbot_high_trust_groups = "3"
+    SiteSetting.chatbot_medium_trust_groups = ""
+    SiteSetting.chatbot_low_trust_groups = ""
+    SiteSetting.chatbot_quota_high_trust = 4
+    SiteSetting.chatbot_quota_medium_trust = 3 
+    SiteSetting.chatbot_quota_low_trust = 2
+    Group.refresh_automatic_groups!(:staff)
+    event = ::DiscourseChatbot::EventEvaluation.new
+    expect(event.over_quota(moderator.id)).to equal(false)
+  end
+
+  it "returns the correct quota decision if staff group exists in a chatbot trust level and user has reached their quota" do
+    UserCustomField.create!(user_id: moderator.id, name: CHATBOT_QUERIES_CUSTOM_FIELD, value: 4)
+    SiteSetting.chatbot_high_trust_groups = "3"
+    SiteSetting.chatbot_medium_trust_groups = ""
+    SiteSetting.chatbot_low_trust_groups = ""
+    SiteSetting.chatbot_quota_high_trust = 4
+    SiteSetting.chatbot_quota_medium_trust = 3 
+    SiteSetting.chatbot_quota_low_trust = 2
+    Group.refresh_automatic_groups!(:staff)
+    event = ::DiscourseChatbot::EventEvaluation.new
+    expect(event.over_quota(moderator.id)).to equal(true)
+  end
+
+end
+
+

--- a/spec/lib/post/post_prompt_utils_spec.rb
+++ b/spec/lib/post/post_prompt_utils_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
-
-#require_relative '../../plugin_helper'
+require_relative '../../plugin_helper'
 
 describe ::DiscourseChatbot::PostPromptUtils do
   let(:topic) { Fabricate(:topic) }

--- a/spec/lib/post/post_prompt_utils_spec.rb
+++ b/spec/lib/post/post_prompt_utils_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../../plugin_helper'
+#require_relative '../../plugin_helper'
 
 describe ::DiscourseChatbot::PostPromptUtils do
   let(:topic) { Fabricate(:topic) }

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -1,15 +1,4 @@
 # frozen_string_literal: true
-## The plugin store is not wiped between each test
 
 require 'webmock/rspec'
-
-RSpec.configure do |config|
-  config.around(:each) do |example|
-    ActiveRecord::Base.transaction do
-      example.run
-      raise ActiveRecord::Rollback
-    end
-  end
-end
-
 require 'rails_helper'


### PR DESCRIPTION
* Fixes the handling of 'everyone' group in chatbot trust levels: membership does not generate a record in GroupUser
* Adds much needed tests to this area of code