### PR TITLE
add Azure's OpenAI support; update `ruby-openai` version

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,7 +1,9 @@
 en:
   site_settings:
     chatbot_enabled: "Enable the chatbot plugin"
-    chatbot_open_ai_token: "Your Open AI token. You can get one at <a target='_blank' rel='noopener' href='https://platform.openai.com/account/api-keys/'>openai.com</a>"
+    chatbot_openai_gpt4_url: "Modify it if you want to use GPT 4 by Azure, e.g. https://custom-domain.openai.azure.com/openai/deployments/DEPLOYMENT)."
+    chatbot_openai_gpt35_url: "Modify it if you want to use GPT 3.5 by Azure, MUST support function calling and ideally is a GPT3.5 16K endpoint)."
+    chatbot_open_ai_token: "Your Open AI token. You can get one at <a target='_blank' rel='noopener' href='https://platform.openai.com/account/api-keys/'>openai.com</a>. Can also be Azure's Open AI token"
     chatbot_open_ai_model_custom: "Use Custom model name (ADVANCED USERS ONLY)"
     chatbot_open_ai_model_custom_name: "(CUSTOM ONLY) Name of model"
     chatbot_open_ai_model_custom_type: "(CUSTOM ONLY) IMPORTANT: Select which type of Open AI endpoint should be used, Chat (ChatGPT style), or Completion (Davinci style) - will break if you select wrong type"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -112,3 +112,5 @@ plugins:
   chatbot_enable_verbose_console_response_progress_logging:
     client: false
     default: false
+  chatbot_openai_gpt35_url: "https://api.openai.com/v1/chat/completions"
+  chatbot_openai_gpt4_url: "https://api.openai.com/v1/chat/completions"

--- a/lib/discourse_chatbot/bots/open_ai_bot.rb
+++ b/lib/discourse_chatbot/bots/open_ai_bot.rb
@@ -6,7 +6,27 @@ module ::DiscourseChatbot
   class OpenAIBot < Bot
 
     def initialize
-      @client = ::OpenAI::Client.new(access_token: SiteSetting.chatbot_open_ai_token)
+      if SiteSetting.chatbot_open_ai_model.include?("gpt-3.5") &&
+        SiteSetting.chatbot_openai_gpt35_url.include?("azure")
+        ::OpenAI.configure do |config|
+          config.access_token = SiteSetting.chatbot_open_ai_token
+          config.uri_base = SiteSetting.chatbot_openai_gpt35_url
+          config.api_type = :azure
+          config.api_version = "2023-05-15"
+        end
+        @client = ::OpenAI::Client.new
+      elsif SiteSetting.chatbot_open_ai_model.include?("gpt-4") &&
+        SiteSetting.chatbot_openai_gpt4_url.include?("azure")
+        ::OpenAI.configure do |config|
+          config.access_token = SiteSetting.chatbot_open_ai_token
+          config.uri_base = SiteSetting.chatbot_openai_gpt4_url
+          config.api_type = :azure
+          config.api_version = "2023-05-15"
+        end
+        @client = ::OpenAI::Client.new
+      else
+        @client = ::OpenAI::Client.new(access_token: SiteSetting.chatbot_open_ai_token)
+      end
     end
 
     def get_response(prompt)
@@ -14,23 +34,23 @@ module ::DiscourseChatbot
       model_name = SiteSetting.chatbot_open_ai_model_custom ? SiteSetting.chatbot_open_ai_model_custom_name : SiteSetting.chatbot_open_ai_model
 
       if ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "gpt-4-32k"].include?(SiteSetting.chatbot_open_ai_model) ||
-      (SiteSetting.chatbot_open_ai_model_custom == true && SiteSetting.chatbot_open_ai_model_custom_type == "chat")
+        (SiteSetting.chatbot_open_ai_model_custom == true && SiteSetting.chatbot_open_ai_model_custom_type == "chat")
         response = @client.chat(
           parameters: {
-              model: model_name,
-              messages: prompt,
-              max_tokens: SiteSetting.chatbot_max_response_tokens,
-              temperature: SiteSetting.chatbot_request_temperature / 100.0,
-              top_p: SiteSetting.chatbot_request_top_p / 100.0,
-              frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
-              presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0
+            model: model_name,
+            messages: prompt,
+            max_tokens: SiteSetting.chatbot_max_response_tokens,
+            temperature: SiteSetting.chatbot_request_temperature / 100.0,
+            top_p: SiteSetting.chatbot_request_top_p / 100.0,
+            frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
+            presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0
           })
 
-        if response.parsed_response["error"]
+        if response["error"]
           begin
-            raise StandardError, response.parsed_response["error"]["message"]
+            raise StandardError, response["error"]["message"]
           rescue => e
-            Rails.logger.error ("OpenAIBot: There was a problem: #{e}")
+            Rails.logger.error("OpenAIBot: There was a problem: #{e}")
             I18n.t('chatbot.errors.general')
           end
         else
@@ -41,20 +61,20 @@ module ::DiscourseChatbot
 
         response = @client.completions(
           parameters: {
-              model: SiteSetting.chatbot_open_ai_model,
-              prompt: prompt,
-              max_tokens: SiteSetting.chatbot_max_response_tokens,
-              temperature: SiteSetting.chatbot_request_temperature / 100.0,
-              top_p: SiteSetting.chatbot_request_top_p / 100.0,
-              frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
-              presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0
+            model: SiteSetting.chatbot_open_ai_model,
+            prompt: prompt,
+            max_tokens: SiteSetting.chatbot_max_response_tokens,
+            temperature: SiteSetting.chatbot_request_temperature / 100.0,
+            top_p: SiteSetting.chatbot_request_top_p / 100.0,
+            frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
+            presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0
           })
 
-        if response.parsed_response["error"]
+        if response["error"]
           begin
-            raise StandardError, response.parsed_response["error"]["message"]
+            raise StandardError, response["error"]["message"]
           rescue => e
-            Rails.logger.error ("OpenAIBot: There was a problem: #{e}")
+            Rails.logger.error("OpenAIBot: There was a problem: #{e}")
             I18n.t('chatbot.errors.general')
           end
         else

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,11 +2,15 @@
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
 # version: 0.22
-# authors: merefield
-# url: https://github.com/merefield/discourse-chatbot
+# authors: merefield-fokx
+# url: https://github.com/fokx/discourse-chatbot
 
-gem "httparty", '0.21.0'
-gem "ruby-openai", '3.7.0', { require: false }
+gem 'faraday-net_http', '3.0.2', {require: false }
+gem 'ruby2_keywords', '0.0.5', {require: false }
+gem 'faraday', '2.7.10', {require: false }
+gem 'multipart-post', '2.3.0', {require: false }
+gem 'faraday-multipart', '1.0.4', {require: false }
+gem "ruby-openai", '4.2.0', {require: false }
 
 module ::DiscourseChatbot
   PLUGIN_NAME = "discourse-chatbot"


### PR DESCRIPTION
* add Azure's OpenAI support via custom URL in settings, similar to how `discourse-ai` use Azure
* update `ruby-openai` to latest version; add its dependencies `faraday` and remove `httparty`; change response.parsed_response["key"] to just response["key"] (see `ruby-openai`'s [CHNAGELOG](https://github.com/alexrudall/ruby-openai/blob/main/CHANGELOG.md))