### PR TITLE
FEATURE: add a 'floating chatbot-btn only on homepage' option

### DIFF
--- a/assets/javascripts/discourse/components/chatbot-launch.js
+++ b/assets/javascripts/discourse/components/chatbot-launch.js
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
+import { defaultHomepage } from "discourse/lib/utilities";
 
 export default class ContentLanguageDiscovery extends Component {
   @service siteSettings;
@@ -9,12 +10,15 @@ export default class ContentLanguageDiscovery extends Component {
   @service router;
 
   get showChatbotButton() {
+    const { currentRouteName } = this.router;
     return (
       this.currentUser &&
       this.siteSettings.chat_enabled &&
       this.siteSettings.chatbot_enabled &&
       this.siteSettings.chatbot_permitted_in_chat &&
-      this.siteSettings.chatbot_quick_access_chat_button
+      this.siteSettings.chatbot_quick_access_chat_button &&
+      (currentRouteName === `discovery.${defaultHomepage()}`
+        || !this.siteSettings.chatbot_quick_access_chat_button_only_on_homepage)
     );
   }
 

--- a/assets/javascripts/discourse/components/chatbot-launch.js
+++ b/assets/javascripts/discourse/components/chatbot-launch.js
@@ -17,8 +17,8 @@ export default class ContentLanguageDiscovery extends Component {
       this.siteSettings.chatbot_enabled &&
       this.siteSettings.chatbot_permitted_in_chat &&
       this.siteSettings.chatbot_quick_access_chat_button &&
-      (currentRouteName === `discovery.${defaultHomepage()}`
-        || !this.siteSettings.chatbot_quick_access_chat_button_only_on_homepage)
+      (currentRouteName === `discovery.${defaultHomepage()}` ||
+        !this.siteSettings.chatbot_quick_access_chat_button_only_on_homepage)
     );
   }
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -15,6 +15,7 @@ en:
     chatbot_permitted_categories: "Allow Chatbot to interact only in these Categories if not allowed to play in all"
     chatbot_bot_user: "The Chatbot User"
     chatbot_quick_access_chat_button: "Display floating button which links to direct Chat with the bot"
+    chatbot_quick_access_chat_button_only_on_homepage: "Display floating direct-bot-chat button only on homepage"
     chatbot_quota_high_trust: "The allowed number of bot responses allowed by prompting user per week - high trust groups"
     chatbot_quota_medium_trust: "The allowed number of bot responses allowed by prompting user per week - medium trust groups"
     chatbot_quota_low_trust: "The allowed number of bot responses allowed by prompting user per week - low trust groups"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,6 +11,9 @@ plugins:
   chatbot_quick_access_chat_button:
     default: true
     client: true
+  chatbot_quick_access_chat_button_only_on_homepage:
+    default: true
+    client: true
   chatbot_permitted_all_categories:
     default: true
     client: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.22
+# version: 0.24
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 


### PR DESCRIPTION
Some users in my forum complain that the chatbot-quick-access-chat floating button is annoying, because the button covers content underneath when they browse and it is pretty huge (especially in a mobile browser). 

However I think the button very useful and should appear on the homepage, so I add this feature to allow admin choose whether to make the floating chatbot button **only appears on homepage**. The code checks whether the current page is homepage as illustrated in https://meta.discourse.org/t/add-custom-content-that-only-appears-on-your-homepage/131415 .