### PR TITLE
support custom Open AI model URL, not limited to Azure

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,13 +1,12 @@
 en:
   site_settings:
     chatbot_enabled: "Enable the chatbot plugin"
-    chatbot_open_ai_token: "Your Open AI token. You can get one at <a target='_blank' rel='noopener' href='https://platform.openai.com/account/api-keys/'>openai.com</a>"
-    chatbot_azure_open_ai_model_url: "Populate it if you want to use Azure OpenAI, e.g. https://custom-domain.openai.azure.com/openai/deployments/custom-name)."
-    chatbot_azure_open_ai_token: "Your Azure Open AI token. Required if you supply Azure URL.  You can get one at <a target='_blank' rel='noopener' href='https://portal.azure.com/'>Azure Portal</a>."
+    chatbot_open_ai_token: "Your Open AI token. Will also be used as token if you set a custom URL to service other than Open AI. You can get one at <a target='_blank' rel='noopener' href='https://platform.openai.com/account/api-keys/'>openai.com</a>"
     chatbot_bot_type: "EXPERIMENTAL: To make the bot smarter, use 'agent' (but be aware this uses many more calls to the LLM increasing cost significantly!)"
     chatbot_open_ai_model_custom: "Use Custom model name (ADVANCED USERS ONLY)"
     chatbot_open_ai_model_custom_name: "(CUSTOM ONLY) Name of model"
     chatbot_open_ai_model_custom_type: "(CUSTOM ONLY) IMPORTANT: Select which type of Open AI endpoint should be used, Chat (ChatGPT style), or Completion (Davinci style) - will break if you select wrong type"
+    chatbot_open_ai_model_custom_url: "Populate it if you want to use proxy to Open AI or Azure Open AI, e.g. https://custom-domain.openai.azure.com/openai/deployments/custom-name)."
     chatbot_open_ai_model: "(UNLESS CUSTOM) The model to be accessed. More on supported models at <a target='_blank' rel='noopener' href='https://platform.openai.com/docs/models/overview'>OpenAI: Model overview</a>"
     chatbot_reply_job_time_delay: 'Number of seconds before reply job is run. This helps prevent rate limits being hit and discourages spamming.'
     chatbot_include_whispers_in_post_history: "Include content of whispers in Post history bot sees (careful!)"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,7 +6,9 @@ en:
     chatbot_open_ai_model_custom: "Use Custom model name (ADVANCED USERS ONLY)"
     chatbot_open_ai_model_custom_name: "(CUSTOM ONLY) Name of model"
     chatbot_open_ai_model_custom_type: "(CUSTOM ONLY) IMPORTANT: Select which type of Open AI endpoint should be used, Chat (ChatGPT style), or Completion (Davinci style) - will break if you select wrong type"
-    chatbot_open_ai_model_custom_url: "Populate it if you want to use proxy to Open AI or Azure Open AI, e.g. https://custom-domain.openai.azure.com/openai/deployments/custom-name)."
+    chatbot_open_ai_model_custom_url: "Populate it if you want to use proxy to Open AI or Azure OpenAI, e.g. https://custom-domain.openai.azure.com/openai/deployments/custom-name)."
+    chatbot_open_ai_model_custom_api_type: "Fill in 'azure' if you use Azure OpenAI, otherwise will use Open AI"
+    chatbot_open_ai_model_custom_api_version: "Fill in Azure OpenAI REST API version, default to '2023-05-15'. Required only when 'custom_api_type' is set to 'azure'. Refer to: <a target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/azure/ai-services/openai/reference'>Azure REST API reference</a>"
     chatbot_open_ai_model: "(UNLESS CUSTOM) The model to be accessed. More on supported models at <a target='_blank' rel='noopener' href='https://platform.openai.com/docs/models/overview'>OpenAI: Model overview</a>"
     chatbot_reply_job_time_delay: 'Number of seconds before reply job is run. This helps prevent rate limits being hit and discourages spamming.'
     chatbot_include_whispers_in_post_history: "Include content of whispers in Post history bot sees (careful!)"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,6 +94,12 @@ plugins:
   chatbot_open_ai_model_custom_url:
     client: false
     default: ''
+  chatbot_open_ai_model_custom_api_type:
+    client: false
+    default: ''
+  chatbot_open_ai_model_custom_api_version:
+    client: false
+    default: '2023-05-15'
   chatbot_request_temperature:
     client: false
     default: 100

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,18 +85,15 @@ plugins:
     choices:
       - normal
       - agent
-  chatbot_azure_open_ai_token:
-    client: false
-    default: ''
-  chatbot_azure_open_ai_model_url:
-    client: false
-    default: ''
   chatbot_open_ai_model_custom:
     default: false
     client: false
   chatbot_open_ai_model_custom_name:
     default: ''
     client: false
+  chatbot_open_ai_model_custom_url:
+    client: false
+    default: ''
   chatbot_request_temperature:
     client: false
     default: 100

--- a/lib/discourse_chatbot/bot.rb
+++ b/lib/discourse_chatbot/bot.rb
@@ -5,7 +5,24 @@ module ::DiscourseChatbot
   class Bot
 
     def initialize
-      raise "Overwrite me!"
+      if SiteSetting.chatbot_open_ai_model_custom_api_type == "azure"
+        ::OpenAI.configure do |config|
+          config.access_token = SiteSetting.chatbot_open_ai_token
+          config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
+          config.api_type = :azure
+          config.api_version = SiteSetting.chatbot_open_ai_model_custom_api_version
+        end
+      else
+        if !SiteSetting.chatbot_open_ai_model_custom_url.blank?
+          ::OpenAI.configure do |config|
+            config.access_token = SiteSetting.chatbot_open_ai_token
+            config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
+          end
+          @client = ::OpenAI::Client.new
+        else
+          @client = ::OpenAI::Client.new(access_token: SiteSetting.chatbot_open_ai_token)
+        end
+      end
     end
 
     def get_response(prompt)

--- a/lib/discourse_chatbot/bots/open_ai_agent.rb
+++ b/lib/discourse_chatbot/bots/open_ai_agent.rb
@@ -6,16 +6,23 @@ module ::DiscourseChatbot
   class OpenAIAgent < Bot
 
     def initialize
-      if !SiteSetting.chatbot_open_ai_model_custom_url.blank?
+      if SiteSetting.chatbot_open_ai_model_custom_api_type == "azure"
         ::OpenAI.configure do |config|
           config.access_token = SiteSetting.chatbot_open_ai_token
           config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
           config.api_type = :azure
-          config.api_version = "2023-05-15"
+          config.api_version = SiteSetting.chatbot_open_ai_model_custom_api_version
         end
-        @client = ::OpenAI::Client.new
       else
-        @client = ::OpenAI::Client.new(access_token: SiteSetting.chatbot_open_ai_token)
+        if !SiteSetting.chatbot_open_ai_model_custom_url.blank?
+          ::OpenAI.configure do |config|
+            config.access_token = SiteSetting.chatbot_open_ai_token
+            config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
+          end
+          @client = ::OpenAI::Client.new
+        else
+          @client = ::OpenAI::Client.new(access_token: SiteSetting.chatbot_open_ai_token)
+        end
       end
 
       @model_name = SiteSetting.chatbot_open_ai_model_custom ? SiteSetting.chatbot_open_ai_model_custom_name : SiteSetting.chatbot_open_ai_model
@@ -131,8 +138,8 @@ module ::DiscourseChatbot
         func = @func_mapping[func_name]
         res = func.process(args)
         res
-       rescue
-         "There was something wrong with your function arguments"
+      rescue
+        "There was something wrong with your function arguments"
       end
     end
 

--- a/lib/discourse_chatbot/bots/open_ai_agent.rb
+++ b/lib/discourse_chatbot/bots/open_ai_agent.rb
@@ -6,24 +6,7 @@ module ::DiscourseChatbot
   class OpenAIAgent < Bot
 
     def initialize
-      if SiteSetting.chatbot_open_ai_model_custom_api_type == "azure"
-        ::OpenAI.configure do |config|
-          config.access_token = SiteSetting.chatbot_open_ai_token
-          config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
-          config.api_type = :azure
-          config.api_version = SiteSetting.chatbot_open_ai_model_custom_api_version
-        end
-      else
-        if !SiteSetting.chatbot_open_ai_model_custom_url.blank?
-          ::OpenAI.configure do |config|
-            config.access_token = SiteSetting.chatbot_open_ai_token
-            config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
-          end
-          @client = ::OpenAI::Client.new
-        else
-          @client = ::OpenAI::Client.new(access_token: SiteSetting.chatbot_open_ai_token)
-        end
-      end
+      super
 
       @model_name = SiteSetting.chatbot_open_ai_model_custom ? SiteSetting.chatbot_open_ai_model_custom_name : SiteSetting.chatbot_open_ai_model
 

--- a/lib/discourse_chatbot/bots/open_ai_agent.rb
+++ b/lib/discourse_chatbot/bots/open_ai_agent.rb
@@ -6,10 +6,10 @@ module ::DiscourseChatbot
   class OpenAIAgent < Bot
 
     def initialize
-      if SiteSetting.chatbot_azure_open_ai_model_url.include?("azure")
+      if !SiteSetting.chatbot_open_ai_model_custom_url.blank?
         ::OpenAI.configure do |config|
-          config.access_token = SiteSetting.chatbot_azure_open_ai_token
-          config.uri_base = SiteSetting.chatbot_azure_open_ai_model_url
+          config.access_token = SiteSetting.chatbot_open_ai_token
+          config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
           config.api_type = :azure
           config.api_version = "2023-05-15"
         end

--- a/lib/discourse_chatbot/bots/open_ai_bot.rb
+++ b/lib/discourse_chatbot/bots/open_ai_bot.rb
@@ -6,10 +6,10 @@ module ::DiscourseChatbot
   class OpenAIBot < Bot
 
     def initialize
-      if SiteSetting.chatbot_azure_open_ai_model_url.include?("azure")
+      if !SiteSetting.chatbot_open_ai_model_custom_url.blank?
         ::OpenAI.configure do |config|
-          config.access_token = SiteSetting.chatbot_azure_open_ai_token
-          config.uri_base = SiteSetting.chatbot_azure_open_ai_model_url
+          config.access_token = SiteSetting.chatbot_open_ai_token
+          config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
           config.api_type = :azure
           config.api_version = "2023-05-15"
         end

--- a/lib/discourse_chatbot/bots/open_ai_bot.rb
+++ b/lib/discourse_chatbot/bots/open_ai_bot.rb
@@ -6,16 +6,23 @@ module ::DiscourseChatbot
   class OpenAIBot < Bot
 
     def initialize
-      if !SiteSetting.chatbot_open_ai_model_custom_url.blank?
+      if SiteSetting.chatbot_open_ai_model_custom_api_type == "azure"
         ::OpenAI.configure do |config|
           config.access_token = SiteSetting.chatbot_open_ai_token
           config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
           config.api_type = :azure
-          config.api_version = "2023-05-15"
+          config.api_version = SiteSetting.chatbot_open_ai_model_custom_api_version
         end
-        @client = ::OpenAI::Client.new
       else
-        @client = ::OpenAI::Client.new(access_token: SiteSetting.chatbot_open_ai_token)
+        if !SiteSetting.chatbot_open_ai_model_custom_url.blank?
+          ::OpenAI.configure do |config|
+            config.access_token = SiteSetting.chatbot_open_ai_token
+            config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
+          end
+          @client = ::OpenAI::Client.new
+        else
+          @client = ::OpenAI::Client.new(access_token: SiteSetting.chatbot_open_ai_token)
+        end
       end
     end
 

--- a/lib/discourse_chatbot/bots/open_ai_bot.rb
+++ b/lib/discourse_chatbot/bots/open_ai_bot.rb
@@ -6,24 +6,7 @@ module ::DiscourseChatbot
   class OpenAIBot < Bot
 
     def initialize
-      if SiteSetting.chatbot_open_ai_model_custom_api_type == "azure"
-        ::OpenAI.configure do |config|
-          config.access_token = SiteSetting.chatbot_open_ai_token
-          config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
-          config.api_type = :azure
-          config.api_version = SiteSetting.chatbot_open_ai_model_custom_api_version
-        end
-      else
-        if !SiteSetting.chatbot_open_ai_model_custom_url.blank?
-          ::OpenAI.configure do |config|
-            config.access_token = SiteSetting.chatbot_open_ai_token
-            config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url
-          end
-          @client = ::OpenAI::Client.new
-        else
-          @client = ::OpenAI::Client.new(access_token: SiteSetting.chatbot_open_ai_token)
-        end
-      end
+      super
     end
 
     def get_response(prompt)


### PR DESCRIPTION
* rename `chatbot_azure_open_ai_model_url` to `chatbot_open_ai_model_custom_url`, to support custom Open AI model URL, including but not limited to Azure
* merge `chatbot_azure_open_ai_token` option into `chatbot_open_ai_token`