### PR TITLE
FIX: quick bot chat availability logic

### DIFF
--- a/assets/javascripts/discourse/components/chatbot-launch.js
+++ b/assets/javascripts/discourse/components/chatbot-launch.js
@@ -16,11 +16,13 @@ export default class ContentLanguageDiscovery extends Component {
     const { currentRouteName } = this.router;
     return (
       this.currentUser &&
-      this.siteSettings.chat_enabled &&
       this.siteSettings.chatbot_enabled &&
-      this.siteSettings.chatbot_permitted_in_chat &&
+      currentRouteName === `discovery.${defaultHomepage()}` &&
       this.siteSettings.chatbot_quick_access_talk_button &&
-      currentRouteName === `discovery.${defaultHomepage()}`
+      ((this.siteSettings.chat_enabled &&
+        this.siteSettings.chatbot_permitted_in_chat) ||
+        (this.siteSettings.chatbot_permitted_in_private_messages &&
+          this.siteSettings.chatbot_quick_access_talk_in_private_message))
     );
   }
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ plugins:
     client: true
   chatbot_permitted_in_private_messages:
     default: true
-    client: false
+    client: true
   chatbot_permitted_in_chat:
     default: true
     client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.38
+# version: 0.39
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 


### PR DESCRIPTION
was not exposing icon when chat was disabled but personal messages were permitted.