### PR TITLE
IMPROVE presence handling

### DIFF
--- a/app/jobs/regular/chatbot_reply_job.rb
+++ b/app/jobs/regular/chatbot_reply_job.rb
@@ -43,9 +43,11 @@ class ::Jobs::ChatbotReplyJob < Jobs::Base
 
       permitted_categories = SiteSetting.chatbot_permitted_categories.split('|')
 
-      if is_private_msg
+      begin
         presence = PresenceChannel.new("/discourse-presence/reply/#{post.topic.id}")
         presence.present(user_id: bot_user_id, client_id: "12345")
+      rescue
+        # ignore issues with permissions related to communicating presence
       end
 
       if (is_private_msg && !SiteSetting.chatbot_permitted_in_private_messages)

--- a/lib/discourse_chatbot/post/post_reply_creator.rb
+++ b/lib/discourse_chatbot/post/post_reply_creator.rb
@@ -29,9 +29,11 @@ module ::DiscourseChatbot
 
         is_private_msg = new_post.topic.private_message?
 
-        if is_private_msg
+        begin
           presence = PresenceChannel.new("/discourse-presence/reply/#{@topic_or_channel_id}")
           presence.leave(user_id: @author.id, client_id: "12345")
+        rescue
+          # ignore issues with permissions related to communicating presence
         end
 
         ::DiscourseChatbot.progress_debug_message("6. The Post has been created successfully")

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.46
+# version: 0.47
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 


### PR DESCRIPTION
* in Topics, show a typing indicator when Bot is responding if Bot is permitted to view (add Bot user to required groups), if not ignore issue.