### PR TITLE
EXPERIMENTAL: Vision support

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,6 +11,7 @@ en:
     chatbot_open_ai_model_custom_api_type: "Fill in 'azure' if you use Azure OpenAI, otherwise will use Open AI"
     chatbot_open_ai_model_custom_api_version: "Fill in Azure OpenAI REST API version, default to '2023-05-15'. Required only when 'custom_api_type' is set to 'azure'. Refer to: <a target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/azure/ai-services/openai/reference'>Azure REST API reference</a>"
     chatbot_open_ai_model: "(UNLESS CUSTOM) The model to be accessed. More on supported models at <a target='_blank' rel='noopener' href='https://platform.openai.com/docs/models/overview'>OpenAI: Model overview</a>"
+    chatbot_support_vision: "(EXPERIMENTAL) Support sharing of images with bot.  Must be supported by selected model.  Images must be uploaded to forum and not hotlinked."
     chatbot_reply_job_time_delay: 'Number of seconds before reply job is run. This helps prevent rate limits being hit and discourages spamming.'
     chatbot_include_whispers_in_post_history: "Include content of whispers in Post history bot sees (careful!)"
     chatbot_max_look_behind: "Maximum number of Posts or Chat Messages bot will consider as prompt for completion, the more the more impressive may be its response, but the more costly the interaction will be."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -75,6 +75,9 @@ plugins:
       - gpt-3.5-turbo-16k
       - gpt-4
       - gpt-4-32k
+  chatbot_support_vision:
+    client: false
+    default: false
   chatbot_reply_job_time_delay:
     client: false
     default: 1

--- a/lib/discourse_chatbot/bots/open_ai_bot.rb
+++ b/lib/discourse_chatbot/bots/open_ai_bot.rb
@@ -29,7 +29,10 @@ module ::DiscourseChatbot
           raise StandardError, response["error"]["message"]
         rescue => e
           Rails.logger.error("Chatbot: There was a problem: #{e}")
-          I18n.t('chatbot.errors.general')
+          {
+            reply: I18n.t('chatbot.errors.general'),
+            inner_thoughts: nil
+          }
         end
       else
         {

--- a/lib/discourse_chatbot/message/message_prompt_utils.rb
+++ b/lib/discourse_chatbot/message/message_prompt_utils.rb
@@ -15,10 +15,12 @@ module ::DiscourseChatbot
         text = (cm.user_id == bot_user_id ? "#{cm.message}" : I18n.t("chatbot.prompt.post", username: username, raw: cm.message)) 
         content = []
         content << {"type": "text", "text": text}
-        cm.uploads.each do |ul|
-          if ["png", "webp", "jpg", "jpeg", "gif", "ico", "avif"].include? (ul.extension) 
-            url = Discourse.base_url + ul.url
-            content << { "type": "image_url", "image_url": { "url": url } }
+        if SiteSetting.chatbot_support_vision
+          cm.uploads.each do |ul|
+            if ["png", "webp", "jpg", "jpeg", "gif", "ico", "avif"].include? (ul.extension) 
+              url = Discourse.base_url + ul.url
+              content << { "type": "image_url", "image_url": { "url": url } }
+            end
           end
         end
         { "role": role, "content": content}

--- a/lib/discourse_chatbot/message/message_prompt_utils.rb
+++ b/lib/discourse_chatbot/message/message_prompt_utils.rb
@@ -12,18 +12,18 @@ module ::DiscourseChatbot
       messages += message_collection.reverse.map do |cm|
         username = ::User.find(cm.user_id).username
         role = (cm.user_id == bot_user_id ? "assistant" : "user")
-        text = (cm.user_id == bot_user_id ? "#{cm.message}" : I18n.t("chatbot.prompt.post", username: username, raw: cm.message)) 
+        text = (cm.user_id == bot_user_id ? "#{cm.message}" : I18n.t("chatbot.prompt.post", username: username, raw: cm.message))
         content = []
-        content << {"type": "text", "text": text}
+        content << { "type": "text", "text": text }
         if SiteSetting.chatbot_support_vision
           cm.uploads.each do |ul|
-            if ["png", "webp", "jpg", "jpeg", "gif", "ico", "avif"].include? (ul.extension) 
+            if ["png", "webp", "jpg", "jpeg", "gif", "ico", "avif"].include? (ul.extension)
               url = Discourse.base_url + ul.url
               content << { "type": "image_url", "image_url": { "url": url } }
             end
           end
         end
-        { "role": role, "content": content}
+        { "role": role, "content": content }
       end
 
       messages

--- a/lib/discourse_chatbot/message/message_prompt_utils.rb
+++ b/lib/discourse_chatbot/message/message_prompt_utils.rb
@@ -11,7 +11,17 @@ module ::DiscourseChatbot
 
       messages += message_collection.reverse.map do |cm|
         username = ::User.find(cm.user_id).username
-        { "role": (cm.user_id == bot_user_id ? "assistant" : "user"), "content": (cm.user_id == bot_user_id ? "#{cm.message}" : I18n.t("chatbot.prompt.post", username: username, raw: cm.message)) }
+        role = (cm.user_id == bot_user_id ? "assistant" : "user")
+        text = (cm.user_id == bot_user_id ? "#{cm.message}" : I18n.t("chatbot.prompt.post", username: username, raw: cm.message)) 
+        content = []
+        content << {"type": "text", "text": text}
+        cm.uploads.each do |ul|
+          if ["png", "webp", "jpg", "jpeg", "gif", "ico", "avif"].include? (ul.extension) 
+            url = Discourse.base_url + ul.url
+            content << { "type": "image_url", "image_url": { "url": url } }
+          end
+        end
+        { "role": role, "content": content}
       end
 
       messages

--- a/lib/discourse_chatbot/post/post_prompt_utils.rb
+++ b/lib/discourse_chatbot/post/post_prompt_utils.rb
@@ -16,14 +16,14 @@ module ::DiscourseChatbot
         role = (p.user_id == bot_user_id ? "assistant" : "user")
         text = (p.user_id == bot_user_id ? "#{p.raw}" : I18n.t("chatbot.prompt.post", username: p.user.username, raw: post_content))
         content = []
-        content << {"type": "text", "text": text}
+        content << { "type": "text", "text": text }
         if SiteSetting.chatbot_support_vision
           if p.image_upload_id
             url = Discourse.base_url + Upload.find(p.image_upload_id).url
             content << { "type": "image_url", "image_url": { "url": url } }
           end
         end
-        { "role": role, "content": content}
+        { "role": role, "content": content }
       end
 
       messages

--- a/lib/discourse_chatbot/post/post_prompt_utils.rb
+++ b/lib/discourse_chatbot/post/post_prompt_utils.rb
@@ -17,9 +17,11 @@ module ::DiscourseChatbot
         text = (p.user_id == bot_user_id ? "#{p.raw}" : I18n.t("chatbot.prompt.post", username: p.user.username, raw: post_content))
         content = []
         content << {"type": "text", "text": text}
-        if p.image_upload_id
-          url = Discourse.base_url + Upload.find(p.image_upload_id).url
-          content << { "type": "image_url", "image_url": { "url": url } }
+        if SiteSetting.chatbot_support_vision
+          if p.image_upload_id
+            url = Discourse.base_url + Upload.find(p.image_upload_id).url
+            content << { "type": "image_url", "image_url": { "url": url } }
+          end
         end
         { "role": role, "content": content}
       end

--- a/lib/discourse_chatbot/post/post_prompt_utils.rb
+++ b/lib/discourse_chatbot/post/post_prompt_utils.rb
@@ -14,8 +14,14 @@ module ::DiscourseChatbot
         post_content = p.raw
         post_content.gsub!(/\[quote.*?\](.*?)\[\/quote\]/m, '') if SiteSetting.chatbot_strip_quotes
         role = (p.user_id == bot_user_id ? "assistant" : "user")
-        content = (p.user_id == bot_user_id ? "#{p.raw}" : I18n.t("chatbot.prompt.post", username: p.user.username, raw: post_content))
-        { "role": role , "content": content }
+        text = (p.user_id == bot_user_id ? "#{p.raw}" : I18n.t("chatbot.prompt.post", username: p.user.username, raw: post_content))
+        content = []
+        content << {"type": "text", "text": text}
+        if p.image_upload_id
+          url = Discourse.base_url + Upload.find(p.image_upload_id).url
+          content << { "type": "image_url", "image_url": { "url": url } }
+        end
+        { "role": role, "content": content}
       end
 
       messages

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.6
+# version: 0.61
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 


### PR DESCRIPTION
* FEATURE: supports Open AI models with vision
* Allows the chatbot to discuss the content of an image with the user (in either Chat or in a Post)
* Images must be uploaded to the forum, not hotlinked
* Adds a new setting `chatbot_support_vision` (default OFF) to toggle this because sending image urls to models that don't support vision will result in an error from the API.
* At time of writing only `gpt-4-vision-preview` model supports this.