### PR TITLE
FEATURE: Auto respond categories

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -30,6 +30,7 @@ en:
     chatbot_can_trigger_from_whisper: "Allow Chatbot to be triggered from a whisper (get creative!)"
     chatbot_permitted_all_categories: "Allow Chatbot to interact in any Category"
     chatbot_permitted_categories: "Allow Chatbot to interact only in these Categories if not allowed to play in all"
+    chatbot_auto_respond_categories: "(EXPERIMENTAL) Categories where Chatbot should reply to every first Post"
     chatbot_bot_user: "The Chatbot User"
     chatbot_quick_access_talk_button: "Display floating button which links to direct discussion one-to-one with the bot on specified channel type"
     chatbot_quick_access_talk_button_bot_icon: "Name of icon used for floating quick bot access button.  If blank it will use bot user's avatar instead. (if icon make sure it's permitted and added to svg_icon_subset if necessary)"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -117,6 +117,11 @@ plugins:
     default: ''
     type: category_list
     list_type: "compact"
+  chatbot_auto_respond_categories:
+    client: false
+    default: ''
+    type: category_list
+    list_type: "compact"
   chatbot_quota_high_trust:
     default: 100
     client: false

--- a/lib/discourse_chatbot/post/post_evaluation.rb
+++ b/lib/discourse_chatbot/post/post_evaluation.rb
@@ -30,7 +30,8 @@ module ::DiscourseChatbot
 
         explicit_reply_to_bot = post.reply_to_user_id == bot_user.id
       else
-        if topic.private_message? && (::TopicUser.where(topic_id: topic.id).where(posted: false).uniq(&:user_id).pluck(:user_id).include? bot_user.id)
+        if (topic.private_message? && (::TopicUser.where(topic_id: topic.id).where(posted: false).uniq(&:user_id).pluck(:user_id).include? bot_user.id)) ||
+             (chatbot_auto_respond_categories.include? post.topic.category_id.to_s)
           explicit_reply_to_bot = true
         end
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.83
+# version: 0.84
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/post/post_evaluation_spec.rb
+++ b/spec/lib/post/post_evaluation_spec.rb
@@ -56,7 +56,7 @@ describe ::DiscourseChatbot::PostEvaluation do
 
   it "It does NOT trigger a bot to respond when the first post is in a Category NOT included in auto respond Categories" do
     SiteSetting.chatbot_bot_user = bot_user.username
-    SiteSetting.chatbot_auto_respond_categories = auto_category.to_s
+    SiteSetting.chatbot_auto_respond_categories = auto_category.id.to_s
 
     post =
     PostCreator.create!(

--- a/spec/lib/post/post_evaluation_spec.rb
+++ b/spec/lib/post/post_evaluation_spec.rb
@@ -3,7 +3,10 @@ require_relative '../../plugin_helper'
 
 describe ::DiscourseChatbot::PostEvaluation do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
-  let(:topic) { Fabricate(:topic, user: user) }
+  let(:category) { Fabricate(:category) }
+  let(:auto_category) { Fabricate(:category) }
+  let(:topic) { Fabricate(:topic, user: user, category: category) }
+  let(:topic_in_auto_category) { Fabricate(:topic, category: auto_category) }
   let(:post_args) { { user: topic.user, topic: topic } }
   let(:bot_user) { Fabricate(:user, refresh_auto_groups: true) }
   let(:other_user) { Fabricate(:user, refresh_auto_groups: true) }
@@ -23,6 +26,42 @@ describe ::DiscourseChatbot::PostEvaluation do
     post =
     PostCreator.create!(
       topic.user,
+      title: "hello there, how are we all doing?!",
+      raw: "hello there!"
+    )
+
+    event_evaluation = ::DiscourseChatbot::PostEvaluation.new
+    triggered = event_evaluation.on_submission(post)
+
+    expect(triggered).to equal(false)
+  end
+
+  it "It does trigger a bot to respond when the first post is in a Category included in auto respond Categories" do
+    SiteSetting.chatbot_bot_user = bot_user.username
+    SiteSetting.chatbot_auto_respond_categories = auto_category.id.to_s
+
+    post =
+    PostCreator.create!(
+      topic_in_auto_category.user,
+      topic_id: topic_in_auto_category.id,
+      title: "hello there, how are we all doing?!",
+      raw: "hello there!"
+    )
+
+    event_evaluation = ::DiscourseChatbot::PostEvaluation.new
+    triggered = event_evaluation.on_submission(post)
+
+    expect(triggered).to equal(true)
+  end
+
+  it "It does NOT trigger a bot to respond when the first post is in a Category NOT included in auto respond Categories" do
+    SiteSetting.chatbot_bot_user = bot_user.username
+    SiteSetting.chatbot_auto_respond_categories = auto_category.to_s
+
+    post =
+    PostCreator.create!(
+      topic.user,
+      topic_id: topic.id,
       title: "hello there, how are we all doing?!",
       raw: "hello there!"
     )


### PR DESCRIPTION
* NEW EXPERIMENTAL FEATURE: auto post after every new Topic first Post in set categories
* New setting `chatbot_auto_respond_categories`, default blank, a list of Categories you want the bot to respond to first posts with.