### PR TITLE
FEATURE: support for new Open AI embedding model

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -17,6 +17,7 @@ en:
     chatbot_open_ai_model_custom_high_trust: "(HIGH TRUST USERS) Use Custom model name (ADVANCED USERS ONLY)"
     chatbot_open_ai_model_custom_name_high_trust: "(HIGH TRUST USERS, CUSTOM ONLY) Name of model"
     chatbot_open_ai_model_custom_url_high_trust: "Populate it if you want to use proxy to Open AI or Azure OpenAI, e.g. https://custom-domain.openai.azure.com/openai/deployments/custom-name."
+    chatbot_open_ai_embeddings_model: "For Embeddings only.  Open AI model used to capture embeddings for search.  Use latest model for highest performance.  If you change this setting you must recreate embeddings for your entire site by running the rake task: `rake chatbot:refresh_embeddings`.  See supported models at <a target='_blank' rel='noopener' href='https://platform.openai.com/docs/models/embeddings'>OpenAI: Embedding Models</a>"
     chatbot_open_ai_embeddings_char_limit: "Maximum number of Post characters sent to Open AI to calculate embedding.  Keep as high as possible without experiencing an error"
     chatbot_open_ai_embeddings_model_custom_url: "For Embeddings only.  Populate it if you want to use proxy to Open AI or Azure OpenAI, e.g. https://custom-domain.openai.azure.com/openai/deployments/embeddings-custom-name."
     chatbot_open_ai_model_custom_api_version: "Azure OpenAI REST API version. Required only when 'custom_api_type' is set to 'azure'. Refer to: <a target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/azure/ai-services/openai/reference'>Azure REST API reference</a>"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,6 +104,13 @@ plugins:
   chatbot_open_ai_model_custom_api_version:
     client: false
     default: '2023-09-01-preview'
+  chatbot_open_ai_embeddings_model:
+    client: false
+    type: enum
+    default: text-embedding-ada-002
+    choices:
+      - text-embedding-ada-002
+      - text-embedding-3-small
   chatbot_open_ai_embeddings_char_limit:
     client: false
     default: 11500

--- a/lib/discourse_chatbot/post_embedding_process.rb
+++ b/lib/discourse_chatbot/post_embedding_process.rb
@@ -20,7 +20,7 @@ module ::DiscourseChatbot
           config.api_version = SiteSetting.chatbot_open_ai_model_custom_api_version
         end
       end
-      @model_name = ::DiscourseChatbot::EMBEDDING_MODEL
+      @model_name = SiteSetting.chatbot_open_ai_embeddings_model
       @client = ::OpenAI::Client.new
 
       allowed_group_ids = [0, 10, 11, 12, 13, 14]  # automated groups only

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.816
+# version: 0.817
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 
@@ -24,7 +24,6 @@ module ::DiscourseChatbot
   CHATBOT_QUERIES_CUSTOM_FIELD = "chatbot_queries"
   POST_TYPES_REGULAR_ONLY = [1]
   POST_TYPES_INC_WHISPERS = [1, 4]
-  EMBEDDING_MODEL = "text-embedding-ada-002".freeze
 
   TRUST_LEVELS = ["low", "medium", "high"]
   HIGH_TRUST_LEVEL = 3


### PR DESCRIPTION
* supports the new, higher performance and cheaper(5x!), 3rd generation model `text-embedding-3-small` which conveniently has the same dimensions, so no changes to the DB are required.
* introduces new setting `chatbot_open_ai_embeddings_model` which defaults to current model, so if you don't want to change it, you don't have to do anything.
* requires refresh of all embeddings with rake task `rake chatbot:refresh_embeddings` without any arguments.
* only relevant to those who use bot in "RAG" mode