### PR TITLE
IMPROVE: use Chat Completions name attribute to simplify code

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -105,8 +105,6 @@ en:
           private: You are a helpful assistant.  You have great tools in the form of functions that give you the power to get newer information. Only use the functions you have been provided with.  The current date and time is %{current_date_time}.  When referring to users by name, include an @ symbol directly in front of their username.  Only respond to the last question, using the prior information as context, if appropriate.
           illegal_urls: "Your last response contained at least one URL which was not valid, please remove it and try again."
       title: "The subject of this conversation is %{topic_title}"
-      first_post: "The first thing someone said was %{username} who said %{raw}"
-      post: "%{username} said %{raw}"
       private_message:
         title_creation: "Create a short Topic title from summarising the prior messages"
       function:

--- a/lib/discourse_chatbot/message/message_prompt_utils.rb
+++ b/lib/discourse_chatbot/message/message_prompt_utils.rb
@@ -12,7 +12,7 @@ module ::DiscourseChatbot
       messages += message_collection.reverse.map do |cm|
         username = ::User.find(cm.user_id).username
         role = (cm.user_id == bot_user_id ? "assistant" : "user")
-        text = (cm.user_id == bot_user_id ? "#{cm.message}" : I18n.t("chatbot.prompt.post", username: username, raw: cm.message))
+        text = cm.message
         content = []
 
         if SiteSetting.chatbot_support_vision == "directly"
@@ -26,7 +26,7 @@ module ::DiscourseChatbot
         else
           content = text
         end
-        { "role": role, "content": content }
+        { "role": role, "name": username, "content": content }
       end
 
       messages

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 0.9.46
+# version: 1.0.0
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 


### PR DESCRIPTION
When Chatbot was first written, the OpenAI API was a little lacking in features.

So to fake different users you had to literally state who said what: "Robert said 'I like bananas' "

But for a while now they've had a `name` attribute, so we can simplify the code and get rid of a couple of localised strings, hoorah!

https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages