### PR TITLE
FEATURE: make name attribute optional

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -19,7 +19,7 @@ en:
     chatbot_open_ai_model_custom_url_high_trust: "Populate it if you want to use proxy to Open AI or Azure OpenAI, e.g. https://custom-domain.openai.azure.com/openai/deployments/custom-name."
     chatbot_open_ai_model_custom_api_version: "Azure OpenAI REST API version. Required only when 'custom_api_type' is set to 'azure'. Refer to: <a target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/azure/ai-services/openai/reference'>Azure REST API reference</a>"
     chatbot_open_ai_model_custom_api_type: "Fill in 'azure' if you use Azure OpenAI, otherwise will use Open AI"
-    chatbot_open_ai_model: "(UNLESS CUSTOM) The model to be accessed. More on supported models at <a target='_blank' rel='noopener' href='https://platform.openai.com/docs/models/overview'>OpenAI: Model overview</a>"
+    chatbot_api_supports_name_attribute: "Check to use API message prompt name attribute for usersnames.  May not work for some locales and models.  Keep unchecked if unsure."
     chatbot_support_vision: "(EXPERIMENTAL) Bot 'Vision': support sharing of images with bot so you can ask it to describe them.  Images must be uploaded to forum and not hotlinked and in RAG mode bot can only see images in current Post it's responding to.  Requires compatible model to be selected.  'false' switches vision off, 'directly' will share images potentially on every call, 'via_function' will only share images when requested by a function which might turn out to be cheaper if main model is older generation"
     chatbot_open_ai_vision_model: "(EXPERIMENTAL) Open AI Vision model used when 'via_function' or 'directly' options are selected.  Used for all interaction if 'directly' is set, overriding all other model settings - caution: monitor costs, this might be expensive!"
     chatbot_support_picture_creation: "(EXPERIMENTAL) Bot 'Paint': support creation of images based on text descriptions.  Currently powered by DALL-E using the same token Open AI token"
@@ -105,6 +105,8 @@ en:
           private: You are a helpful assistant.  You have great tools in the form of functions that give you the power to get newer information. Only use the functions you have been provided with.  The current date and time is %{current_date_time}.  When referring to users by name, include an @ symbol directly in front of their username.  Only respond to the last question, using the prior information as context, if appropriate.
           illegal_urls: "Your last response contained at least one URL which was not valid, please remove it and try again."
       title: "The subject of this conversation is %{topic_title}"
+      first_post: "The first thing someone said was %{username} who said %{raw}"
+      post: "%{username} said %{raw}"
       private_message:
         title_creation: "Create a short Topic title from summarising the prior messages"
       function:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -113,6 +113,9 @@ plugins:
   chatbot_open_ai_model_custom_api_version:
     client: false
     default: '2023-09-01-preview'
+  chatbot_api_supports_name_attribute:
+    client: false
+    default: false
   chatbot_embeddings_enabled:
     default: false
     client: false

--- a/lib/discourse_chatbot/message/message_prompt_utils.rb
+++ b/lib/discourse_chatbot/message/message_prompt_utils.rb
@@ -1,38 +1,44 @@
 # frozen_string_literal: true
 module ::DiscourseChatbot
   class MessagePromptUtils < PromptUtils
-
     def self.create_prompt(opts)
-
       message_collection = collect_past_interactions(opts[:reply_to_message_or_post_id])
       bot_user_id = opts[:bot_user_id]
 
       messages = []
 
-      messages += message_collection.reverse.map do |cm|
-        username = ::User.find(cm.user_id).username
-        role = (cm.user_id == bot_user_id ? "assistant" : "user")
-        text = SiteSetting.chatbot_api_supports_name_attribute || cm.user_id == bot_user_id ?
-          cm.message :
-          I18n.t("chatbot.prompt.post", username: username, raw: cm.message)
+      messages +=
+        message_collection.reverse.map do |cm|
+          username = ::User.find(cm.user_id).username
+          role = (cm.user_id == bot_user_id ? "assistant" : "user")
+          text =
+            (
+              if SiteSetting.chatbot_api_supports_name_attribute || cm.user_id == bot_user_id
+                cm.message
+              else
+                I18n.t("chatbot.prompt.post", username: username, raw: cm.message)
+              end
+            )
 
-        content = []
+          content = []
 
-        if SiteSetting.chatbot_support_vision == "directly"
-          content << { "type": "text", "text": text }
-          cm.uploads.each do |ul|
-            if ["png", "webp", "jpg", "jpeg", "gif", "ico", "avif"].include?(ul.extension)
-              url = resolve_full_url(ul.url)
-              content << { "type": "image_url", "image_url": { "url": url } }
+          if SiteSetting.chatbot_support_vision == "directly"
+            content << { type: "text", text: text }
+            cm.uploads.each do |ul|
+              if %w[png webp jpg jpeg gif ico avif].include?(ul.extension)
+                url = resolve_full_url(ul.url)
+                content << { type: "image_url", image_url: { url: url } }
+              end
             end
+          else
+            content = text
           end
-        else
-          content = text
+          if SiteSetting.chatbot_api_supports_name_attribute
+            { role: role, name: username, content: content }
+          else
+            { role: role, content: content }
+          end
         end
-        SiteSetting.chatbot_api_supports_name_attribute ?
-          { "role": role, "name": username, "content": content } :
-          { "role": role, "content": content }
-      end
 
       messages
     end
@@ -46,12 +52,15 @@ module ::DiscourseChatbot
 
       collect_amount = SiteSetting.chatbot_max_look_behind
 
-      while message_collection.length < collect_amount do
-
+      while message_collection.length < collect_amount
         if current_message.in_reply_to_id
           current_message = ::Chat::Message.find(current_message.in_reply_to_id)
         else
-          prior_message = ::Chat::Message.where(chat_channel_id: current_message.chat_channel_id, deleted_at: nil).where('chat_messages.id < ?', current_message.id).last
+          prior_message =
+            ::Chat::Message
+              .where(chat_channel_id: current_message.chat_channel_id, deleted_at: nil)
+              .where("chat_messages.id < ?", current_message.id)
+              .last
           if prior_message.nil?
             break
           else

--- a/lib/discourse_chatbot/message/message_prompt_utils.rb
+++ b/lib/discourse_chatbot/message/message_prompt_utils.rb
@@ -12,7 +12,10 @@ module ::DiscourseChatbot
       messages += message_collection.reverse.map do |cm|
         username = ::User.find(cm.user_id).username
         role = (cm.user_id == bot_user_id ? "assistant" : "user")
-        text = cm.message
+        text = SiteSetting.chatbot_api_supports_name_attribute || cm.user_id == bot_user_id ?
+          cm.message :
+          I18n.t("chatbot.prompt.post", username: username, raw: cm.message)
+
         content = []
 
         if SiteSetting.chatbot_support_vision == "directly"
@@ -26,7 +29,9 @@ module ::DiscourseChatbot
         else
           content = text
         end
-        { "role": role, "name": username, "content": content }
+        SiteSetting.chatbot_api_supports_name_attribute ?
+          { "role": role, "name": username, "content": content } :
+          { "role": role, "content": content }
       end
 
       messages

--- a/lib/discourse_chatbot/post/post_prompt_utils.rb
+++ b/lib/discourse_chatbot/post/post_prompt_utils.rb
@@ -1,55 +1,114 @@
 # frozen_string_literal: true
 module ::DiscourseChatbot
-
   class PostPromptUtils < PromptUtils
-
     def self.create_prompt(opts)
       post_collection = collect_past_interactions(opts[:reply_to_message_or_post_id])
       original_post_number = opts[:original_post_number]
       bot_user_id = opts[:bot_user_id]
       category_id = opts[:category_id]
-      first_post_role = post_collection.first.topic.first_post.user.id == bot_user_id ? "assistant" : "user"
+      first_post_role =
+        post_collection.first.topic.first_post.user.id == bot_user_id ? "assistant" : "user"
 
-      messages = SiteSetting.chatbot_api_supports_name_attribute || post_collection.first.topic.first_post.user.id == bot_user_id ?
-        [{ "role": first_post_role, "name": post_collection.first.topic.first_post.user.username, "content":  I18n.t("chatbot.prompt.title", topic_title: post_collection.first.topic.title) }] :
-        [{ "role": first_post_role, "content":  I18n.t("chatbot.prompt.title", topic_title: post_collection.first.topic.title) }]
-
-      messages << SiteSetting.chatbot_api_supports_name_attribute || post_collection.first.topic.first_post.user.id == bot_user_id ?
-        { "role": first_post_role, "name": post_collection.first.topic.first_post.user.username, "content": post_collection.first.topic.first_post.raw } :
-        { "role": first_post_role, "content": post_collection.first.topic.first_post.raw }
-
-      if original_post_number == 1 && (Array(SiteSetting.chatbot_auto_respond_categories.split("|")).include? category_id.to_s) &&
-        !CategoryCustomField.find_by(category_id: category_id, name: "chatbot_auto_response_additional_prompt").blank?
-        messages << SiteSetting.chatbot_api_supports_name_attribute || post_collection.first.topic.first_post.user.id == bot_user_id ?
-          { "role": first_post_role, "name": post_collection.first.topic.first_post.user.username, "content": CategoryCustomField.find_by(category_id: category_id, name: "chatbot_auto_response_additional_prompt").value } :
-          { "role": first_post_role, "content": CategoryCustomField.find_by(category_id: category_id, name: "chatbot_auto_response_additional_prompt").value }
-      end
-
-      messages += post_collection.reverse.map do |p|
-        post_content = p.raw
-        post_content.gsub!(/\[quote.*?\](.*?)\[\/quote\]/m, '') if SiteSetting.chatbot_strip_quotes
-        role = (p.user_id == bot_user_id ? "assistant" : "user")
-        name = p.user.username
-
-        text = SiteSetting.chatbot_api_supports_name_attribute || p.user_id == bot_user_id ?
-                 post_content :
-                 I18n.t("chatbot.prompt.post", username: p.user.username, raw: post_content)
-        username = p.user.username
-        content = []
-
-        if SiteSetting.chatbot_support_vision == "directly"
-          content << { "type": "text", "text": text }
-          if p.image_upload_id
-            url = resolve_full_url(Upload.find(p.image_upload_id).url)
-            content << { "type": "image_url", "image_url": { "url": url } }
+      messages =
+        (
+          if SiteSetting.chatbot_api_supports_name_attribute ||
+               post_collection.first.topic.first_post.user.id == bot_user_id
+            [
+              {
+                role: first_post_role,
+                name: post_collection.first.topic.first_post.user.username,
+                content:
+                  I18n.t("chatbot.prompt.title", topic_title: post_collection.first.topic.title),
+              },
+            ]
+          else
+            [
+              {
+                role: first_post_role,
+                content:
+                  I18n.t("chatbot.prompt.title", topic_title: post_collection.first.topic.title),
+              },
+            ]
           end
-        else
-          content = text
-        end
-        SiteSetting.chatbot_api_supports_name_attribute ?
-          { "role": role, "name": username, "content": content } :
-          { "role": role, "content": content }
+        )
+
+      if messages << SiteSetting.chatbot_api_supports_name_attribute ||
+           post_collection.first.topic.first_post.user.id == bot_user_id
+        {
+          role: first_post_role,
+          name: post_collection.first.topic.first_post.user.username,
+          content: post_collection.first.topic.first_post.raw,
+        }
+      else
+        { role: first_post_role, content: post_collection.first.topic.first_post.raw }
       end
+
+      if original_post_number == 1 &&
+           (
+             Array(SiteSetting.chatbot_auto_respond_categories.split("|")).include? category_id.to_s
+           ) &&
+           !CategoryCustomField.find_by(
+             category_id: category_id,
+             name: "chatbot_auto_response_additional_prompt",
+           ).blank?
+        if messages << SiteSetting.chatbot_api_supports_name_attribute ||
+             post_collection.first.topic.first_post.user.id == bot_user_id
+          {
+            role: first_post_role,
+            name: post_collection.first.topic.first_post.user.username,
+            content:
+              CategoryCustomField.find_by(
+                category_id: category_id,
+                name: "chatbot_auto_response_additional_prompt",
+              ).value,
+          }
+        else
+          {
+            role: first_post_role,
+            content:
+              CategoryCustomField.find_by(
+                category_id: category_id,
+                name: "chatbot_auto_response_additional_prompt",
+              ).value,
+          }
+        end
+      end
+
+      messages +=
+        post_collection.reverse.map do |p|
+          post_content = p.raw
+          if SiteSetting.chatbot_strip_quotes
+            post_content.gsub!(%r{\[quote.*?\](.*?)\[/quote\]}m, "")
+          end
+          role = (p.user_id == bot_user_id ? "assistant" : "user")
+          name = p.user.username
+
+          text =
+            (
+              if SiteSetting.chatbot_api_supports_name_attribute || p.user_id == bot_user_id
+                post_content
+              else
+                I18n.t("chatbot.prompt.post", username: p.user.username, raw: post_content)
+              end
+            )
+          username = p.user.username
+          content = []
+
+          if SiteSetting.chatbot_support_vision == "directly"
+            content << { type: "text", text: text }
+            if p.image_upload_id
+              url = resolve_full_url(Upload.find(p.image_upload_id).url)
+              content << { type: "image_url", image_url: { url: url } }
+            end
+          else
+            content = text
+          end
+          if SiteSetting.chatbot_api_supports_name_attribute
+            { role: role, name: username, content: content }
+          else
+            { role: role, content: content }
+          end
+        end
 
       messages
     end
@@ -59,25 +118,52 @@ module ::DiscourseChatbot
 
       post_collection = []
 
-      accepted_post_types = SiteSetting.chatbot_include_whispers_in_post_history ? ::DiscourseChatbot::POST_TYPES_INC_WHISPERS : ::DiscourseChatbot::POST_TYPES_REGULAR_ONLY
+      accepted_post_types =
+        (
+          if SiteSetting.chatbot_include_whispers_in_post_history
+            ::DiscourseChatbot::POST_TYPES_INC_WHISPERS
+          else
+            ::DiscourseChatbot::POST_TYPES_REGULAR_ONLY
+          end
+        )
 
       post_collection << current_post
 
       collect_amount = SiteSetting.chatbot_max_look_behind
 
-      while post_collection.length < collect_amount do
+      while post_collection.length < collect_amount
         break if current_post.reply_to_post_number == 1
         if current_post.reply_to_post_number
-          linked_post = ::Post.find_by(topic_id: current_post.topic_id, post_number: current_post.reply_to_post_number)
+          linked_post =
+            ::Post.find_by(
+              topic_id: current_post.topic_id,
+              post_number: current_post.reply_to_post_number,
+            )
           if linked_post
             current_post = linked_post
           else
-            current_post = ::Post.where(topic_id: current_post.topic_id, post_type: accepted_post_types, deleted_at: nil).where('post_number < ?', current_post.reply_to_post_number).last
+            current_post =
+              ::Post
+                .where(
+                  topic_id: current_post.topic_id,
+                  post_type: accepted_post_types,
+                  deleted_at: nil,
+                )
+                .where("post_number < ?", current_post.reply_to_post_number)
+                .last
             break if current_post.post_number == 1
           end
         else
           if current_post.post_number > 1
-            current_post = ::Post.where(topic_id: current_post.topic_id, post_type: accepted_post_types, deleted_at: nil).where('post_number < ?', current_post.post_number).last
+            current_post =
+              ::Post
+                .where(
+                  topic_id: current_post.topic_id,
+                  post_type: accepted_post_types,
+                  deleted_at: nil,
+                )
+                .where("post_number < ?", current_post.post_number)
+                .last
             break if current_post.post_number == 1
           else
             break

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 1.0.2
+# version: 1.0.3
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/post/post_prompt_utils_spec.rb
+++ b/spec/lib/post/post_prompt_utils_spec.rb
@@ -28,31 +28,31 @@ describe ::DiscourseChatbot::PostPromptUtils do
   it "captures the right history" do
     SiteSetting.chatbot_include_whispers_in_post_history = false
 
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_1.id)
-    expect(past_posts.count).to equal(1)
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_6.id)
-    expect(past_posts.count).to equal(4)
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_11.id)
-    expect(past_posts.count).to equal(6)
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_1)
+    expect(past_posts.count).to equal(0)
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_6)
+    expect(past_posts.count).to equal(3)
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_11)
+    expect(past_posts.count).to equal(5)
 
     post_9.destroy
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_11.id)
-    expect(past_posts.count).to equal(6)
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_11)
+    expect(past_posts.count).to equal(5)
   end
 
   it "captures the right history when whispers are included" do
     SiteSetting.chatbot_include_whispers_in_post_history = true
 
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_1.id)
-    expect(past_posts.count).to equal(1)
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_6.id)
-    expect(past_posts.count).to equal(4)
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_11.id)
-    expect(past_posts.count).to equal(7)
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_1)
+    expect(past_posts.count).to equal(0)
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_6)
+    expect(past_posts.count).to equal(3)
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_11)
+    expect(past_posts.count).to equal(6)
 
     post_9.destroy
-    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_11.id)
-    expect(past_posts.count).to equal(7)
+    past_posts = ::DiscourseChatbot::PostPromptUtils.collect_past_interactions(post_11)
+    expect(past_posts.count).to equal(6)
   end
 
   it "adds the category specific prompt when in an auto-response category" do
@@ -66,10 +66,13 @@ describe ::DiscourseChatbot::PostPromptUtils do
       category_id: auto_category.id,
       original_post_number: 1
     }
-
     prompt = ::DiscourseChatbot::PostPromptUtils.create_prompt(opts)
 
-    expect(prompt[2][:content].to_s).to eq(text.to_s)
+    expect(prompt.count).to eq(3)
+    expect(prompt[2][:content].to_s).to eq(
+      I18n.t("chatbot.prompt.post",
+      username: post_1_auto.user.username,
+      raw: text))
   end
 
   it "does not add the category specific prompt when in an auto-response category for subsequent posts" do
@@ -86,6 +89,6 @@ describe ::DiscourseChatbot::PostPromptUtils do
 
     prompt = ::DiscourseChatbot::PostPromptUtils.create_prompt(opts)
 
-    expect(prompt[2][:content].to_s).not_to eq(text.to_s)
+    expect(prompt.count).to eq(2)
   end
 end


### PR DESCRIPTION
Adds a setting `chatbot_api_supports_name_attribute` (default OFF) to enable the use of the name attribute supported by Open AI for username.

When off it will add username in any case to the user message aka "merefield said blah"

This PR also cleans up the Post history algorithm so it doesn't duplicate the first post of a Topic, thereby saving tokens.