### PR TITLE
FEATURE: update model selection with new OpenAI 4.1 models

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,9 +39,11 @@ plugins:
   chatbot_open_ai_model_high_trust:
     client: false
     type: enum
-    default: gpt-4o-mini
+    default: gpt-4.1-nano
     choices:
-      - gpt-3.5-turbo
+      - gpt-4.1
+      - gpt-4.1-mini
+      - gpt-4.1-nano
       - gpt-4o
       - gpt-4o-mini
       - gpt-4-turbo
@@ -70,9 +72,11 @@ plugins:
   chatbot_open_ai_model_medium_trust:
     client: false
     type: enum
-    default: gpt-4o-mini
+    default: gpt-4.1-nano
     choices:
-      - gpt-3.5-turbo
+      - gpt-4.1
+      - gpt-4.1-mini
+      - gpt-4.1-nano
       - gpt-4o
       - gpt-4o-mini
       - gpt-4-turbo
@@ -101,9 +105,11 @@ plugins:
   chatbot_open_ai_model_low_trust:
     client: false
     type: enum
-    default: gpt-4o-mini
+    default: gpt-4.1-nano
     choices:
-      - gpt-3.5-turbo
+      - gpt-4.1
+      - gpt-4.1-mini
+      - gpt-4.1-nano
       - gpt-4o
       - gpt-4o-mini
       - gpt-4-turbo
@@ -253,8 +259,11 @@ plugins:
   chatbot_open_ai_vision_model:
     client: false
     type: enum
-    default: gpt-4o-mini
+    default: gpt-4o
     choices:
+      - gpt-4.1
+      - gpt-4.1-mini
+      - gpt-4.1-nano
       - gpt-4o
       - gpt-4o-mini
       - gpt-4-turbo

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Discourse Chat, Topics and Private Messages
-# version: 1.4.8
+# version: 1.4.9
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 


### PR DESCRIPTION
* adds `gpt-4.1`, `gpt-4.1-mini` and `gpt-4.1-nano` notable for cheaper pricing and hugely increased context windows.
* removes `gpt-3.5-turbo`

see https://openai.com/index/gpt-4-1/