### PR TITLE
add gpt-5 models

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,14 +39,11 @@ plugins:
   chatbot_open_ai_model_high_trust:
     client: false
     type: enum
-    default: gpt-4o-mini
+    default: gpt-5-mini
     choices:
-      - gpt-4.1
-      - gpt-4.1-mini
-      - gpt-4.1-nano
-      - gpt-4o
-      - gpt-4o-mini
-      - gpt-4-turbo
+      - gpt-5
+      - gpt-5-mini
+      - gpt-5-nano
       - o4-mini
       - o3
       - o3-mini
@@ -71,14 +68,11 @@ plugins:
   chatbot_open_ai_model_medium_trust:
     client: false
     type: enum
-    default: gpt-4o-mini
+    default: gpt-5-mini
     choices:
-      - gpt-4.1
-      - gpt-4.1-mini
-      - gpt-4.1-nano
-      - gpt-4o
-      - gpt-4o-mini
-      - gpt-4-turbo
+      - gpt-5
+      - gpt-5-mini
+      - gpt-5-nano
       - o4-mini
       - o3
       - o3-mini
@@ -103,14 +97,11 @@ plugins:
   chatbot_open_ai_model_low_trust:
     client: false
     type: enum
-    default: gpt-4o-mini
+    default: gpt-5-mini
     choices:
-      - gpt-4.1
-      - gpt-4.1-mini
-      - gpt-4.1-nano
-      - gpt-4o
-      - gpt-4o-mini
-      - gpt-4-turbo
+      - gpt-5
+      - gpt-5-mini
+      - gpt-5-nano
       - o4-mini
       - o3
       - o3-mini
@@ -270,14 +261,11 @@ plugins:
   chatbot_open_ai_vision_model:
     client: false
     type: enum
-    default: gpt-4o
+    default: gpt-5
     choices:
-      - gpt-4.1
-      - gpt-4.1-mini
-      - gpt-4.1-nano
-      - gpt-4o
-      - gpt-4o-mini
-      - gpt-4-turbo
+      - gpt-5
+      - gpt-5-mini
+      - gpt-5-nano
       - o4-mini
       - o3
       - o3-mini


### PR DESCRIPTION
This pull request updates the default and available model choices for several chatbot OpenAI model settings in `config/settings.yml`. The main change is migrating from GPT-4 variants to newer GPT-5 models for high, medium, and low trust levels, as well as for vision model configuration.

**Chatbot model configuration updates:**

* Changed the default model for `chatbot_open_ai_model_high_trust`, `chatbot_open_ai_model_medium_trust`, and `chatbot_open_ai_model_low_trust` from `gpt-4o-mini` to `gpt-5-mini`, and updated their choices to include only GPT-5 variants (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`). [[1]](diffhunk://#diff-e769bbb8c1ba3711c5403b424ed9c218ffafba7f1890ee394717196f28ff4540L42-R46) [[2]](diffhunk://#diff-e769bbb8c1ba3711c5403b424ed9c218ffafba7f1890ee394717196f28ff4540L74-R75) [[3]](diffhunk://#diff-e769bbb8c1ba3711c5403b424ed9c218ffafba7f1890ee394717196f28ff4540L106-R104)
* Changed the default model for `chatbot_open_ai_vision_model` from `gpt-4o` to `gpt-5`, and updated its choices to include only GPT-5 variants.