### PR TITLE
FEATURE: Add current OpenAI models

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -55,7 +55,7 @@ en:
     chatbot_high_trust_groups: "Groups considered high trust for bot interaction"
     chatbot_medium_trust_groups: "Groups considered medium trust for bot interaction"
     chatbot_low_trust_groups: "Groups considered low trust for bot interaction"
-    chatbot_open_ai_model_reasoning_level: "Amount of permitting reasoning.  Higher levels allow more complex reasoning but may be more expensive."
+    chatbot_open_ai_model_reasoning_level: "Reasoning effort used for compatible models. Supported levels vary by model; higher levels allow more complex reasoning but may be slower and more expensive."
     chatbot_open_ai_include_reasoning_summaries: "Include model-generated reasoning summaries in the RAG bot's inner-thoughts trace. Disable this if your custom OpenAI-compatible endpoint does not support reasoning summaries."
     chatbot_open_ai_model_verbosity: "Verbosity used for reasoning-capable models only."
     chatbot_request_temperature: "Numeric value within the range of 0 to 200 to determine the level of randomization for AI responses. Higher temp = more creative, lower temp = more conservative. Refer to: <a target='_blank' rel='noopener' href='https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature/'>API docs: temperature</a>"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,18 +44,26 @@ plugins:
     type: enum
     default: gpt-4.1-mini
     choices:
+      - gpt-5.6
+      - gpt-5.6-sol
+      - gpt-5.6-terra
+      - gpt-5.6-luna
+      - gpt-5.5
+      - gpt-5.5-pro
+      - gpt-5.4
+      - gpt-5.4-pro
+      - gpt-5.4-mini
+      - gpt-5.4-nano
+      - gpt-5.2
+      - gpt-5.2-pro
+      - gpt-5.1
+      - gpt-5
+      - gpt-5-pro
+      - gpt-5-mini
+      - gpt-5-nano
       - gpt-4.1
       - gpt-4.1-mini
       - gpt-4.1-nano
-      - gpt-5.4
-      - gpt-5.4-mini
-      - gpt-5.4-nano
-      - gpt-5
-      - gpt-5-mini
-      - gpt-5-nano
-      - gpt-5.1
-      - gpt-5.2
-      - gpt-5.2-pro
   chatbot_open_ai_model_custom_high_trust:
     default: false
     client: false
@@ -77,18 +85,26 @@ plugins:
     type: enum
     default: gpt-4.1-mini
     choices:
+      - gpt-5.6
+      - gpt-5.6-sol
+      - gpt-5.6-terra
+      - gpt-5.6-luna
+      - gpt-5.5
+      - gpt-5.5-pro
+      - gpt-5.4
+      - gpt-5.4-pro
+      - gpt-5.4-mini
+      - gpt-5.4-nano
+      - gpt-5.2
+      - gpt-5.2-pro
+      - gpt-5.1
+      - gpt-5
+      - gpt-5-pro
+      - gpt-5-mini
+      - gpt-5-nano
       - gpt-4.1
       - gpt-4.1-mini
       - gpt-4.1-nano
-      - gpt-5.4
-      - gpt-5.4-mini
-      - gpt-5.4-nano
-      - gpt-5
-      - gpt-5-mini
-      - gpt-5-nano
-      - gpt-5.1
-      - gpt-5.2
-      - gpt-5.2-pro
   chatbot_open_ai_model_custom_medium_trust:
     default: false
     client: false
@@ -110,18 +126,26 @@ plugins:
     type: enum
     default: gpt-4.1-mini
     choices:
+      - gpt-5.6
+      - gpt-5.6-sol
+      - gpt-5.6-terra
+      - gpt-5.6-luna
+      - gpt-5.5
+      - gpt-5.5-pro
+      - gpt-5.4
+      - gpt-5.4-pro
+      - gpt-5.4-mini
+      - gpt-5.4-nano
+      - gpt-5.2
+      - gpt-5.2-pro
+      - gpt-5.1
+      - gpt-5
+      - gpt-5-pro
+      - gpt-5-mini
+      - gpt-5-nano
       - gpt-4.1
       - gpt-4.1-mini
       - gpt-4.1-nano
-      - gpt-5.4
-      - gpt-5.4-mini
-      - gpt-5.4-nano
-      - gpt-5
-      - gpt-5-mini
-      - gpt-5-nano
-      - gpt-5.1
-      - gpt-5.2
-      - gpt-5.2-pro
   chatbot_open_ai_model_custom_low_trust:
     default: false
     client: false
@@ -142,6 +166,7 @@ plugins:
       - medium
       - high
       - xhigh
+      - max
   chatbot_open_ai_include_reasoning_summaries:
     client: false
     default: true
@@ -295,15 +320,23 @@ plugins:
     type: enum
     default: gpt-4.1
     choices:
+      - gpt-5.6
+      - gpt-5.6-sol
+      - gpt-5.6-terra
+      - gpt-5.6-luna
+      - gpt-5.5
+      - gpt-5.5-pro
       - gpt-5.4
+      - gpt-5.4-pro
       - gpt-5.4-mini
       - gpt-5.4-nano
       - gpt-5.2
       - gpt-5.2-pro
       - gpt-5.1
+      - gpt-5
+      - gpt-5-pro
       - gpt-5-mini
       - gpt-5-nano
-      - gpt-5
       - gpt-4.1
       - gpt-4.1-mini
       - gpt-4.1-nano

--- a/plugin.rb
+++ b/plugin.rb
@@ -52,10 +52,18 @@ module ::DiscourseChatbot
     o3
     o3-mini
     o4-mini
+    gpt-5.6
+    gpt-5.6-sol
+    gpt-5.6-terra
+    gpt-5.6-luna
+    gpt-5.5
+    gpt-5.5-pro
     gpt-5.4
     gpt-5.4-mini
     gpt-5.4-nano
+    gpt-5.4-pro
     gpt-5
+    gpt-5-pro
     gpt-5-mini
     gpt-5-nano
     gpt-5.1

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Chat, Topics and Private Messages
-# version: 2.0.0
+# version: 2.0.1
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/bot/open_ai_bot_basic_spec.rb
+++ b/spec/lib/bot/open_ai_bot_basic_spec.rb
@@ -7,8 +7,8 @@ describe ::DiscourseChatbot::OpenAiBotBasic do
   let(:responses_api) { mock }
 
   before do
-    SiteSetting.chatbot_open_ai_model_low_trust = "gpt-5.4-mini"
-    SiteSetting.chatbot_open_ai_model_reasoning_level = "high"
+    SiteSetting.chatbot_open_ai_model_low_trust = "gpt-5.6-sol"
+    SiteSetting.chatbot_open_ai_model_reasoning_level = "max"
     SiteSetting.chatbot_open_ai_model_verbosity = "low"
 
     OpenAI::Client.stubs(:new).returns(client)
@@ -22,8 +22,8 @@ describe ::DiscourseChatbot::OpenAiBotBasic do
       .with do |args|
         parameters = args[:parameters]
 
-        expect(parameters[:model]).to eq("gpt-5.4-mini")
-        expect(parameters[:reasoning]).to eq({ effort: "high" })
+        expect(parameters[:model]).to eq("gpt-5.6-sol")
+        expect(parameters[:reasoning]).to eq({ effort: "max" })
         expect(parameters[:text]).to eq({ verbosity: "low" })
         expect(parameters[:max_output_tokens]).to eq(25_000)
         expect(parameters[:input].first[:role]).to eq("developer")


### PR DESCRIPTION
Previously, the main OpenAI model selectors stopped at GPT-5.4, omitted current Pro and GPT-5.6 variants, and could not select the newer `max` reasoning effort.

This change synchronizes the low-, medium-, high-trust, and vision selectors with current general-purpose OpenAI models, routes the new reasoning models through the Responses API, adds `max` effort support, and bumps the plugin to 2.0.1; validation covered 70 focused RSpec examples, YAML/Ruby syntax, selector consistency, and diff checks.
