### PR TITLE
FIX: Improve calculator tool recovery

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -204,7 +204,8 @@ en:
               Action Input: NOW - DURATION(2, days)
           parameters:
             input: the mathematical expression to evaluate using the supported formula syntax.
-          error: "'%{parameter}' is not a valid supported mathematical expression"
+          error: "'%{parameter}' is not a valid supported mathematical expression. Use Dentaku expression syntax such as '3 * PI', and correct the expression before retrying."
+          repeated_error: "'%{parameter}' was already rejected. Do not retry it unchanged. Use Dentaku expression syntax such as '3 * PI', or continue without the calculation."
         paint:
           description: |
             creates a picture based on the provided description

--- a/lib/discourse_chatbot/calculator.rb
+++ b/lib/discourse_chatbot/calculator.rb
@@ -26,11 +26,11 @@ module DiscourseChatbot
     end
 
     def evaluate
-      validate_expression!
+      expression = validated_expression
 
       result =
         @calculator.disable_cache do |calculator|
-          calculator.evaluate!(@expression, pi: Math::PI, e: Math::E, now: @now)
+          calculator.evaluate!(expression, pi: Math::PI, e: Math::E, now: @now)
         end
 
       validate_result!(result)
@@ -41,7 +41,7 @@ module DiscourseChatbot
 
     private
 
-    def validate_expression!
+    def validated_expression
       if !@expression.is_a?(String) || @expression.blank? || !@expression.valid_encoding?
         raise InvalidExpression, "The expression must be a valid non-empty string"
       end
@@ -50,10 +50,16 @@ module DiscourseChatbot
         raise InvalidExpression, "The expression is too long"
       end
 
-      tokens = @calculator.tokenizer.tokenize(@expression)
+      expression = normalize_expression(@expression)
+      tokens = @calculator.tokenizer.tokenize(expression)
       raise InvalidExpression, "The expression is too complex" if tokens.length > MAX_TOKENS
 
       validate_tokens!(tokens)
+      expression
+    end
+
+    def normalize_expression(expression)
+      expression.gsub(/\bMath(?:::|\.)PI\b/i, "PI").gsub(/\bMath(?:::|\.)E\b/i, "E").gsub("π", "PI")
     end
 
     def validate_tokens!(tokens)

--- a/lib/discourse_chatbot/tools/calculator.rb
+++ b/lib/discourse_chatbot/tools/calculator.rb
@@ -26,21 +26,36 @@ module DiscourseChatbot
       end
 
       def process(args)
+        input = args[parameters[0][:name]]
+        if failed_inputs.include?(input)
+          return(
+            {
+              answer: I18n.t("chatbot.prompt.function.calculator.repeated_error", parameter: input),
+              token_usage: 0,
+            }
+          )
+        end
+
         super(args)
 
+        { answer: ::DiscourseChatbot::Calculator.evaluate(input), token_usage: 0 }
+      rescue ::DiscourseChatbot::Calculator::InvalidExpression
+        failed_inputs << input
         {
-          answer: ::DiscourseChatbot::Calculator.evaluate(args[parameters[0][:name]]),
+          answer: I18n.t("chatbot.prompt.function.calculator.error", parameter: input),
           token_usage: 0,
         }
       rescue StandardError
         {
-          answer:
-            I18n.t(
-              "chatbot.prompt.function.calculator.error",
-              parameter: args[parameters[0][:name]],
-            ),
+          answer: I18n.t("chatbot.prompt.function.calculator.error", parameter: input),
           token_usage: 0,
         }
+      end
+
+      private
+
+      def failed_inputs
+        @failed_inputs ||= []
       end
     end
   end

--- a/lib/discourse_chatbot/tools/calculator.rb
+++ b/lib/discourse_chatbot/tools/calculator.rb
@@ -27,6 +27,8 @@ module DiscourseChatbot
 
       def process(args)
         input = args[parameters[0][:name]]
+        super(args)
+
         if failed_inputs.include?(input)
           return(
             {
@@ -35,8 +37,6 @@ module DiscourseChatbot
             }
           )
         end
-
-        super(args)
 
         { answer: ::DiscourseChatbot::Calculator.evaluate(input), token_usage: 0 }
       rescue ::DiscourseChatbot::Calculator::InvalidExpression

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Chat, Topics and Private Messages
-# version: 2.4.0
+# version: 2.4.1
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/calculator_spec.rb
+++ b/spec/lib/calculator_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe DiscourseChatbot::Calculator do
       expect(described_class.evaluate("NOW - DURATION(2, days)", now:)).to eq(now - 2.days)
     end
 
+    it "normalizes common aliases for mathematical constants" do
+      expect(described_class.evaluate("3 * Math::PI")).to be_within(0.000_001).of(3 * Math::PI)
+      expect(described_class.evaluate("Math.PI + Math::E + Math.E + π")).to be_within(0.000_001).of(
+        2 * Math::PI + 2 * Math::E,
+      )
+    end
+
     it "rejects Ruby code and host resource access" do
       expressions = [
         "system('id')",

--- a/spec/lib/tools/calculator_spec.rb
+++ b/spec/lib/tools/calculator_spec.rb
@@ -30,4 +30,16 @@ describe ::DiscourseChatbot::Tools::Calculator do
       },
     )
   end
+
+  it "validates malformed arguments before rejecting a repeated expression" do
+    args = { "input" => "File.read('/etc/passwd')" }
+    calc.process(args)
+
+    expect(calc.process(args.merge("unexpected" => "value"))).to eq(
+      {
+        answer: I18n.t("chatbot.prompt.function.calculator.error", parameter: args["input"]),
+        token_usage: 0,
+      },
+    )
+  end
 end

--- a/spec/lib/tools/calculator_spec.rb
+++ b/spec/lib/tools/calculator_spec.rb
@@ -4,18 +4,28 @@ require_relative "../../plugin_helper"
 describe ::DiscourseChatbot::Tools::Calculator do
   let(:calc) { ::DiscourseChatbot::Tools::Calculator.new }
 
-  it "returns the calculation result" do
-    args = { "input" => "3 + 4" }
+  it "returns the calculation result for a common model-generated constant" do
+    args = { "input" => "3 * Math::PI" }
 
-    expect(calc.process(args)).to eq({ answer: 7, token_usage: 0 })
+    result = calc.process(args)
+
+    expect(result[:answer]).to be_within(0.000_001).of(3 * Math::PI)
+    expect(result[:token_usage]).to eq(0)
   end
 
-  it "returns a translated error for unsupported expressions" do
+  it "returns correction guidance and rejects an unchanged failed expression" do
     args = { "input" => "File.read('/etc/passwd')" }
 
     expect(calc.process(args)).to eq(
       {
         answer: I18n.t("chatbot.prompt.function.calculator.error", parameter: args["input"]),
+        token_usage: 0,
+      },
+    )
+    expect(calc.process(args)).to eq(
+      {
+        answer:
+          I18n.t("chatbot.prompt.function.calculator.repeated_error", parameter: args["input"]),
         token_usage: 0,
       },
     )


### PR DESCRIPTION
Previously, calculator calls emitted by models could fail on familiar `Math::PI`-style aliases, and generic error feedback allowed an unchanged invalid expression to be retried.

This change normalizes common constant aliases into Dentaku expression syntax, gives the model actionable correction guidance, avoids reevaluating identical rejected inputs, adds regression coverage, and bumps the plugin version to 2.4.1. Validated with `bin/lint --fix` across all changed files and the complete non-system plugin spec suite (170 examples, 0 failures).
