### PR TITLE
PERF: Maximize prompt cache reuse

### DIFF
--- a/app/controllers/discourse_chatbot/chatbot_controller.rb
+++ b/app/controllers/discourse_chatbot/chatbot_controller.rb
@@ -27,10 +27,7 @@ module ::DiscourseChatbot
 
       if !post_id && start_bot.tool_enabled?("user_information") &&
            start_bot.has_empty_user_fields?(opts)
-        system_message = {
-          role: "system",
-          content: I18n.t("chatbot.prompt.system.rag.private", current_date_time: DateTime.current),
-        }
+        system_message = { role: "system", content: I18n.t("chatbot.prompt.system.rag.private") }
         assistant_message = {
           role: "assistant",
           content:
@@ -45,21 +42,18 @@ module ::DiscourseChatbot
 
         messages = [system_message, assistant_message]
 
-        model = start_bot.model_name
-
         if start_bot.reasoning_model?
           res =
             start_bot.client.responses.create(parameters: start_bot.responses_parameters(messages))
           kick_off_statement = start_bot.responses_text(res)
         else
-          parameters = {
-            model: model,
-            messages: messages,
-            temperature: SiteSetting.chatbot_request_temperature / 100.0,
-            top_p: SiteSetting.chatbot_request_top_p / 100.0,
-            frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
-            presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0,
-          }
+          parameters =
+            start_bot.chat_completions_parameters(messages).merge(
+              temperature: SiteSetting.chatbot_request_temperature / 100.0,
+              top_p: SiteSetting.chatbot_request_top_p / 100.0,
+              frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
+              presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0,
+            )
           parameters.merge!(start_bot.completion_token_limit_parameters)
 
           res = start_bot.client.chat(parameters: parameters)
@@ -68,10 +62,7 @@ module ::DiscourseChatbot
         end
       elsif post_id
         post = ::Post.find_by(id: post_id)
-        system_message = {
-          role: "system",
-          content: I18n.t("chatbot.prompt.system.rag.private", current_date_time: DateTime.current),
-        }
+        system_message = { role: "system", content: I18n.t("chatbot.prompt.system.rag.private") }
 
         opts[:reply_to_message_or_post_id] = post_id
 
@@ -94,20 +85,18 @@ module ::DiscourseChatbot
               username: current_user.username,
             ),
         }
-        model = start_bot.model_name
         if start_bot.reasoning_model?
           res =
             start_bot.client.responses.create(parameters: start_bot.responses_parameters(messages))
           kick_off_statement = start_bot.responses_text(res)
         else
-          parameters = {
-            model: model,
-            messages: messages,
-            temperature: SiteSetting.chatbot_request_temperature / 100.0,
-            top_p: SiteSetting.chatbot_request_top_p / 100.0,
-            frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
-            presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0,
-          }
+          parameters =
+            start_bot.chat_completions_parameters(messages).merge(
+              temperature: SiteSetting.chatbot_request_temperature / 100.0,
+              top_p: SiteSetting.chatbot_request_top_p / 100.0,
+              frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
+              presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0,
+            )
           parameters.merge!(start_bot.completion_token_limit_parameters)
           res = start_bot.client.chat(parameters: parameters)
           kick_off_statement = res.dig("choices", 0, "message", "content")

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -180,7 +180,7 @@ en:
           error: "I couldn't save any information about %{user_field} for answer '%{answer}'"
         calculator:
           description: |
-            Evaluate one expression using Dentaku formula syntax, not Ruby syntax. Use this tool for arithmetic, comparisons, mathematical functions, and calculations involving the current date or time.
+            Evaluate one expression using Dentaku formula syntax, not Ruby syntax. Use this tool for arithmetic, comparisons, mathematical functions, and calculations involving the current date or time. Always call this tool with `NOW` when asked for the current date or time; never infer the current date or time yourself.
 
             Formula syntax requirements:
             - Syntax is case-insensitive. Use operators such as `+`, `-`, `*`, `/`, `%`, `=`, `!=`, `<`, `<=`, `>`, and `>=`.

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -120,7 +120,7 @@ en:
         rag:
           open: You are a helpful assistant. You have tools that give you the power to get newer information. Only use the tools you have been provided with. When referring to users by name, include an @ symbol directly in front of their username. Only respond to the last question, using the prior information as context, if appropriate.
           private: You are a helpful assistant. You have tools that give you the power to get newer information. Only use the tools you have been provided with. When referring to users by name, include an @ symbol directly in front of their username. Only respond to the last question, using the prior information as context, if appropriate.
-          current_date_time: The current date and time is %{current_date_time}.
+          current_date: The current date is %{current_date}.
           illegal_urls: "Your last response contained at least one URL which was not valid, please remove it and try again."
           advanced_local_reasoning:
             alternative: "Produce an independent alternative answer to the user's request using the conversation and tool results above. Return only the answer, without mentioning another draft."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -118,8 +118,9 @@ en:
     prompt:
       system:
         rag:
-          open: You are a helpful assistant. You have tools that give you the power to get newer information. Only use the tools you have been provided with. The current date and time is %{current_date_time}. When referring to users by name, include an @ symbol directly in front of their username. Only respond to the last question, using the prior information as context, if appropriate.
-          private: You are a helpful assistant. You have tools that give you the power to get newer information. Only use the tools you have been provided with. The current date and time is %{current_date_time}. When referring to users by name, include an @ symbol directly in front of their username. Only respond to the last question, using the prior information as context, if appropriate.
+          open: You are a helpful assistant. You have tools that give you the power to get newer information. Only use the tools you have been provided with. When referring to users by name, include an @ symbol directly in front of their username. Only respond to the last question, using the prior information as context, if appropriate.
+          private: You are a helpful assistant. You have tools that give you the power to get newer information. Only use the tools you have been provided with. When referring to users by name, include an @ symbol directly in front of their username. Only respond to the last question, using the prior information as context, if appropriate.
+          current_date_time: The current date and time is %{current_date_time}.
           illegal_urls: "Your last response contained at least one URL which was not valid, please remove it and try again."
           advanced_local_reasoning:
             alternative: "Produce an independent alternative answer to the user's request using the conversation and tool results above. Return only the answer, without mentioning another draft."

--- a/lib/discourse_chatbot/bot.rb
+++ b/lib/discourse_chatbot/bot.rb
@@ -128,12 +128,19 @@ module ::DiscourseChatbot
       system_message[:prompt_cache_breakpoint] = true if @llm_client.explicit_prompt_caching?
       prompt.unshift(system_message)
 
-      dynamic_system_message =
-        I18n.t("chatbot.prompt.system.rag.current_date_time", current_date_time: DateTime.current)
-      if private_discussion && (system_message_suffix = get_system_message_suffix(opts)).present?
-        dynamic_system_message += "  #{system_message_suffix}"
+      dynamic_system_message_parts = []
+      if !tool_enabled?("calculate")
+        dynamic_system_message_parts << I18n.t(
+          "chatbot.prompt.system.rag.current_date",
+          current_date: Date.current.iso8601,
+        )
       end
-      prompt << { role: "developer", content: dynamic_system_message }
+      if private_discussion && (system_message_suffix = get_system_message_suffix(opts)).present?
+        dynamic_system_message_parts << system_message_suffix
+      end
+      if dynamic_system_message_parts.present?
+        prompt.insert(1, { role: "developer", content: dynamic_system_message_parts.join("  ") })
+      end
 
       @initial_inner_thoughts = Array(opts[:initial_inner_thoughts]).deep_dup
       @inner_thoughts = []

--- a/lib/discourse_chatbot/bot.rb
+++ b/lib/discourse_chatbot/bot.rb
@@ -13,7 +13,7 @@ module ::DiscourseChatbot
     class ChainLimitError < NonRetryableError
     end
 
-    attr_reader :client, :model_name, :total_tokens
+    attr_reader :cache_write_tokens, :cached_tokens, :client, :model_name, :total_tokens
 
     BUILT_IN_TOOL_CLASSES = %w[
       DiscourseChatbot::Tools::StockData
@@ -46,6 +46,8 @@ module ::DiscourseChatbot
       @client = @llm_client.client
       @model_name = @llm_client.model_name
       @total_tokens = 0
+      @cached_tokens = 0
+      @cache_write_tokens = 0
       @enabled_tool_names = configured_tool_names(opts[:trust_level])
       if tools
         merge_tools(opts)
@@ -89,6 +91,10 @@ module ::DiscourseChatbot
       )
     end
 
+    def chat_completions_parameters(messages)
+      @llm_client.chat_completions_parameters(messages)
+    end
+
     def responses_tools
       @llm_client.responses_tools(@tool_definitions)
     end
@@ -115,27 +121,19 @@ module ::DiscourseChatbot
 
     def get_response(prompt, opts)
       private_discussion = opts[:private] || false
+      system_message = {
+        role: "developer",
+        content: I18n.t("chatbot.prompt.system.rag.#{private_discussion ? "private" : "open"}"),
+      }
+      system_message[:prompt_cache_breakpoint] = true if @llm_client.explicit_prompt_caching?
+      prompt.unshift(system_message)
 
-      if private_discussion
-        system_message = {
-          role: "developer",
-          content: I18n.t("chatbot.prompt.system.rag.private", current_date_time: DateTime.current),
-        }
-
-        system_message_suffix = get_system_message_suffix(opts)
-        system_message[:content] += "  " + system_message_suffix if system_message_suffix.present?
-      else
-        system_message = {
-          role: "developer",
-          content: I18n.t("chatbot.prompt.system.rag.open", current_date_time: DateTime.current),
-        }
+      dynamic_system_message =
+        I18n.t("chatbot.prompt.system.rag.current_date_time", current_date_time: DateTime.current)
+      if private_discussion && (system_message_suffix = get_system_message_suffix(opts)).present?
+        dynamic_system_message += "  #{system_message_suffix}"
       end
-
-      if tool_enabled?("user_information")
-        prompt << system_message
-      else
-        prompt.unshift(system_message)
-      end
+      prompt << { role: "developer", content: dynamic_system_message }
 
       @initial_inner_thoughts = Array(opts[:initial_inner_thoughts]).deep_dup
       @inner_thoughts = []
@@ -153,6 +151,8 @@ module ::DiscourseChatbot
         reply: res["choices"][0]["message"]["content"],
         inner_thoughts: inner_thoughts,
         total_tokens: @total_tokens,
+        cached_tokens: @cached_tokens,
+        cache_write_tokens: @cache_write_tokens,
       }
     end
 
@@ -322,19 +322,21 @@ module ::DiscourseChatbot
         tools << ::DiscourseChatbot::Tools::StockData.new
       end
 
+      extension_tools = []
       ::DiscourseChatbot::Tool.descendants.each do |tool_class|
         next if BUILT_IN_TOOL_CLASSES.include?(tool_class.to_s)
 
         begin
           next if tool_class.respond_to?(:available?) && !tool_class.available?(opts)
 
-          tools << tool_class.new
+          extension_tools << tool_class.new
         rescue StandardError => error
           Rails.logger.warn(
             "Chatbot: unable to load extension tool #{tool_class}: #{error.class}: #{error.message}",
           )
         end
       end
+      tools.concat(extension_tools.sort_by(&:name))
 
       @tool_definitions = parse_tools(tools)
       @tools = @tool_definitions.map { |tool| { type: "function", function: tool } }.presence
@@ -379,9 +381,11 @@ module ::DiscourseChatbot
               include_reasoning_summary: SiteSetting.chatbot_open_ai_include_reasoning_summaries,
             )
 
-          if use_tools && @tools
+          if @tools
             parameters[:tools] = responses_tools
-            if iteration == 1
+            if !use_tools
+              parameters[:tool_choice] = "none"
+            elsif iteration == 1
               if FORCE_A_TOOL_VALUES.include?(SiteSetting.chatbot_tool_choice_first_iteration)
                 parameters[:tool_choice] = "required"
               elsif SiteSetting.chatbot_tool_choice_first_iteration == FORCE_LOCAL_SEARCH_TOOL
@@ -391,26 +395,26 @@ module ::DiscourseChatbot
           end
 
           raw_response = @client.responses.create(parameters: parameters)
-          token_usage = raw_response.dig("usage", "total_tokens")
-          @total_tokens += token_usage.to_i
+          track_token_usage(raw_response["usage"])
           res = normalize_responses_response(raw_response)
         else
-          parameters = {
-            model: @model_name,
-            messages: messages,
-            temperature: SiteSetting.chatbot_request_temperature / 100.0,
-            top_p: SiteSetting.chatbot_request_top_p / 100.0,
-            frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
-            presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0,
-          }
+          parameters =
+            chat_completions_parameters(messages).merge(
+              temperature: SiteSetting.chatbot_request_temperature / 100.0,
+              top_p: SiteSetting.chatbot_request_top_p / 100.0,
+              frequency_penalty: SiteSetting.chatbot_request_frequency_penalty / 100.0,
+              presence_penalty: SiteSetting.chatbot_request_presence_penalty / 100.0,
+            )
           parameters.merge!(completion_token_limit_parameters)
           include_logprobs = uncertainty_guided_reasoning? if include_logprobs.nil?
           parameters[:logprobs] = true if include_logprobs && @logprobs_supported != false
           parameters.merge!(parameter_overrides)
 
-          if use_tools && @tools
+          if @tools
             parameters.merge!(tools: @tools)
-            if iteration == 1
+            if !use_tools
+              parameters[:tool_choice] = "none"
+            elsif iteration == 1
               if FORCE_A_TOOL_VALUES.include?(SiteSetting.chatbot_tool_choice_first_iteration)
                 parameters.merge!(tool_choice: "required")
               elsif SiteSetting.chatbot_tool_choice_first_iteration == FORCE_LOCAL_SEARCH_TOOL
@@ -438,8 +442,7 @@ module ::DiscourseChatbot
             )
             res = @client.chat(parameters: parameters)
           end
-          token_usage = res.dig("usage", "total_tokens")
-          @total_tokens += token_usage.to_i
+          track_token_usage(res["usage"])
         end
 
         ::DiscourseChatbot.progress_debug_message <<~EOS
@@ -551,6 +554,21 @@ module ::DiscourseChatbot
 
         iteration += 1
       end
+    end
+
+    def track_token_usage(usage)
+      usage = usage.to_h.with_indifferent_access
+      @total_tokens += usage[:total_tokens].to_i
+      cache_details = usage[:input_tokens_details] || usage[:prompt_tokens_details] || {}
+      cache_details = cache_details.with_indifferent_access
+      cached_tokens = cache_details[:cached_tokens].to_i
+      cache_write_tokens = cache_details[:cache_write_tokens].to_i
+      @cached_tokens += cached_tokens
+      @cache_write_tokens += cache_write_tokens
+
+      ::DiscourseChatbot.progress_debug_message(
+        "Prompt cache usage: cached #{cached_tokens} tokens, wrote #{cache_write_tokens} tokens",
+      )
     end
 
     def apply_advanced_local_reasoning(res, messages, iteration, max_iterations)

--- a/lib/discourse_chatbot/llm_client.rb
+++ b/lib/discourse_chatbot/llm_client.rb
@@ -10,13 +10,13 @@ module DiscourseChatbot
     attr_reader :client, :model_name
 
     def initialize(opts)
-      custom_uri_base = custom_uri_base(opts)
+      custom_api_url = custom_uri_base(opts)
       @official_openai_endpoint =
-        custom_uri_base.blank? && SiteSetting.chatbot_open_ai_model_custom_api_type != "azure"
+        custom_api_url.blank? && SiteSetting.chatbot_open_ai_model_custom_api_type != "azure"
 
       ::OpenAI.configure do |config|
         config.access_token = SiteSetting.chatbot_open_ai_token
-        config.uri_base = custom_uri_base if custom_uri_base.present?
+        config.uri_base = custom_api_url if custom_api_url.present?
 
         if SiteSetting.chatbot_open_ai_model_custom_api_type == "azure"
           config.api_type = :azure

--- a/lib/discourse_chatbot/llm_client.rb
+++ b/lib/discourse_chatbot/llm_client.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "digest"
 require "openai"
 
 module DiscourseChatbot
@@ -9,22 +10,13 @@ module DiscourseChatbot
     attr_reader :client, :model_name
 
     def initialize(opts)
+      custom_uri_base = custom_uri_base(opts)
+      @official_openai_endpoint =
+        custom_uri_base.blank? && SiteSetting.chatbot_open_ai_model_custom_api_type != "azure"
+
       ::OpenAI.configure do |config|
         config.access_token = SiteSetting.chatbot_open_ai_token
-
-        case opts[:trust_level]
-        when TRUST_LEVELS[0], TRUST_LEVELS[1], TRUST_LEVELS[2]
-          if SiteSetting.send(
-               "chatbot_open_ai_model_custom_url_" + opts[:trust_level] + "_trust",
-             ).present?
-            config.uri_base =
-              SiteSetting.send("chatbot_open_ai_model_custom_url_" + opts[:trust_level] + "_trust")
-          end
-        else
-          if SiteSetting.chatbot_open_ai_model_custom_url_low_trust.present?
-            config.uri_base = SiteSetting.chatbot_open_ai_model_custom_url_low_trust
-          end
-        end
+        config.uri_base = custom_uri_base if custom_uri_base.present?
 
         if SiteSetting.chatbot_open_ai_model_custom_api_type == "azure"
           config.api_type = :azure
@@ -51,6 +43,7 @@ module DiscourseChatbot
       @model_name = get_model(opts)
       @model_reasoning_level = SiteSetting.chatbot_open_ai_model_reasoning_level
       @model_verbosity = SiteSetting.chatbot_open_ai_model_verbosity
+      @prompt_cache_key = build_prompt_cache_key(opts)
     end
 
     def get_model(opts)
@@ -75,7 +68,10 @@ module DiscourseChatbot
     end
 
     def responses_parameters(messages, include_reasoning_summary: false)
-      parameters = { model: @model_name, input: responses_input(messages) }
+      parameters = { model: @model_name, input: responses_input(messages) }.merge(
+        prompt_cache_parameters,
+      )
+      parameters[:prompt_cache_options] = { mode: "implicit" } if explicit_prompt_caching?
       reasoning_output_tokens = SiteSetting.chatbot_open_ai_max_reasoning_output_tokens
       parameters[:max_output_tokens] = reasoning_output_tokens if reasoning_output_tokens.positive?
 
@@ -89,6 +85,41 @@ module DiscourseChatbot
       parameters[:text] = text if text.present?
 
       parameters
+    end
+
+    def prompt_cache_parameters
+      @prompt_cache_key ? { prompt_cache_key: @prompt_cache_key } : {}
+    end
+
+    def chat_completions_parameters(messages)
+      { model: @model_name, messages: chat_completions_messages(messages) }.merge(
+        prompt_cache_parameters,
+      )
+    end
+
+    def explicit_prompt_caching?
+      @official_openai_endpoint && @model_name.match?(/\Agpt-5\.6(?:-|\z)/)
+    end
+
+    def chat_completions_messages(messages)
+      return messages if !explicit_prompt_caching?
+
+      messages.map do |message|
+        message = message.deep_symbolize_keys
+        next message.except(:prompt_cache_breakpoint) if !message[:prompt_cache_breakpoint]
+
+        message.except(:prompt_cache_breakpoint).merge(
+          content: [
+            {
+              type: "text",
+              text: message[:content].to_s,
+              prompt_cache_breakpoint: {
+                mode: "explicit",
+              },
+            },
+          ],
+        )
+      end
     end
 
     def completion_token_limit_parameters
@@ -126,15 +157,15 @@ module DiscourseChatbot
           }
         end
       else
-        {
-          role: %w[developer system].include?(role) ? "developer" : role,
-          content: [
-            {
-              type: role == "assistant" ? "output_text" : "input_text",
-              text: message[:content].to_s,
-            },
-          ],
+        content = {
+          type: role == "assistant" ? "output_text" : "input_text",
+          text: message[:content].to_s,
         }
+        if message[:prompt_cache_breakpoint] && explicit_prompt_caching?
+          content[:prompt_cache_breakpoint] = { mode: "explicit" }
+        end
+
+        { role: %w[developer system].include?(role) ? "developer" : role, content: [content] }
       end
     end
 
@@ -255,6 +286,27 @@ module DiscourseChatbot
       end
 
       raise ResponsesApiError, "OpenAI Responses API returned unexpected status: #{status}"
+    end
+
+    private
+
+    def custom_uri_base(opts)
+      trust_level =
+        TRUST_LEVELS.include?(opts[:trust_level]) ? opts[:trust_level] : TRUST_LEVELS.first
+      SiteSetting.send("chatbot_open_ai_model_custom_url_#{trust_level}_trust")
+    end
+
+    def build_prompt_cache_key(opts)
+      return if !@official_openai_endpoint || opts[:topic_or_channel_id].blank?
+
+      context = [
+        Discourse.current_hostname,
+        opts[:type],
+        opts[:topic_or_channel_id],
+        opts[:thread_id] || "root",
+        @model_name,
+      ].join(":")
+      "discourse-chatbot:#{Digest::SHA256.hexdigest(context).first(40)}"
     end
   end
 end

--- a/lib/discourse_chatbot/post/post_reply_creator.rb
+++ b/lib/discourse_chatbot/post/post_reply_creator.rb
@@ -72,7 +72,7 @@ module DiscourseChatbot
               res = bot.client.responses.create(parameters: bot.responses_parameters(messages))
               title = bot.responses_text(res)
             else
-              res = bot.client.chat(parameters: { model: bot.model_name, messages: messages })
+              res = bot.client.chat(parameters: bot.chat_completions_parameters(messages))
               title = res.dig("choices", 0, "message", "content")
             end
 

--- a/lib/discourse_chatbot/tools/escalate_to_staff.rb
+++ b/lib/discourse_chatbot/tools/escalate_to_staff.rb
@@ -206,7 +206,7 @@ module DiscourseChatbot
           res = bot.client.responses.create(parameters: bot.responses_parameters(messages))
           bot.responses_text(res)&.strip
         else
-          res = bot.client.chat(parameters: { model: bot.model_name, messages: messages })
+          res = bot.client.chat(parameters: bot.chat_completions_parameters(messages))
 
           return nil if res["error"].present?
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Chat, Topics and Private Messages
-# version: 2.4.1
+# version: 2.4.2
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/bot_spec.rb
+++ b/spec/lib/bot_spec.rb
@@ -98,11 +98,17 @@ describe ::DiscourseChatbot::Bot do
     system_entry = {
       role: "developer",
       content:
-        "You are a helpful assistant. You have tools that give you the power to get newer information. Only use the tools you have been provided with. The current date and time is 2023-08-18T10:11:44+00:00. When referring to users by name, include an @ symbol directly in front of their username. Only respond to the last question, using the prior information as context, if appropriate.",
+        "You are a helpful assistant. You have tools that give you the power to get newer information. Only use the tools you have been provided with. When referring to users by name, include an @ symbol directly in front of their username. Only respond to the last question, using the prior information as context, if appropriate.",
+    }
+    date_entry = {
+      role: "developer",
+      content: "The current date and time is 2023-08-18T10:11:44+00:00.",
     }
 
-    first_query = get_chatbot_input_fixture("llm_first_query").unshift(system_entry)
+    first_query =
+      get_chatbot_input_fixture("llm_first_query").unshift(system_entry).push(date_entry)
     second_query = get_chatbot_input_fixture("llm_second_query").unshift(system_entry)
+    second_query.insert(2, date_entry)
 
     described_class
       .any_instance
@@ -118,6 +124,108 @@ describe ::DiscourseChatbot::Bot do
     expect(rag.get_response(query, opts)[:reply]).to eq(
       llm_final_response["choices"][0]["message"]["content"],
     )
+  end
+
+  it "optimizes official Chat Completions requests for prompt caching" do
+    SiteSetting.chatbot_open_ai_model_low_trust = "gpt-4.1-mini"
+    SiteSetting.chatbot_chain_of_thought_max_iterations = 1
+    DateTime.stubs(:current).returns("2026-08-16T12:00:00+00:00")
+    request = nil
+    bot_opts = { type: ::DiscourseChatbot::POST, topic_or_channel_id: 42, trust_level: "low" }
+
+    client
+      .expects(:chat)
+      .with do |args|
+        request = args[:parameters]
+        true
+      end
+      .returns(
+        completion_response.call("Done").deep_merge(
+          "usage" => {
+            "prompt_tokens_details" => {
+              "cached_tokens" => 120,
+              "cache_write_tokens" => 30,
+            },
+          },
+        ),
+      )
+
+    response =
+      described_class.new(bot_opts).get_response([{ role: "user", content: "Help me" }], bot_opts)
+
+    expect(request[:prompt_cache_key]).to match(/\Adiscourse-chatbot:[0-9a-f]{40}\z/)
+    expect(request[:messages].first[:content]).not_to include("current date")
+    expect(request[:messages].last[:content]).to eq(
+      "The current date and time is 2026-08-16T12:00:00+00:00.",
+    )
+    expect(request).to include(tool_choice: "none")
+    expect(request[:tools]).to be_present
+    expect(response).to include(cached_tokens: 120, cache_write_tokens: 30)
+  end
+
+  it "uses an explicit stable-prefix breakpoint for GPT-5.6 Responses requests" do
+    SiteSetting.chatbot_open_ai_model_low_trust = "gpt-5.6"
+    SiteSetting.chatbot_chain_of_thought_max_iterations = 1
+    DateTime.stubs(:current).returns("2026-08-16T12:00:00+00:00")
+    request = nil
+    bot_opts = {
+      type: ::DiscourseChatbot::MESSAGE,
+      topic_or_channel_id: 7,
+      thread_id: 9,
+      trust_level: "low",
+    }
+
+    responses_api
+      .expects(:create)
+      .with do |args|
+        request = args[:parameters]
+        true
+      end
+      .returns(
+        {
+          "status" => "completed",
+          "output" => [
+            { "type" => "message", "content" => [{ "type" => "output_text", "text" => "Done" }] },
+          ],
+          "usage" => {
+            "total_tokens" => 200,
+            "input_tokens_details" => {
+              "cached_tokens" => 150,
+              "cache_write_tokens" => 25,
+            },
+          },
+        },
+      )
+
+    response =
+      described_class.new(bot_opts).get_response([{ role: "user", content: "Help me" }], bot_opts)
+
+    stable_content = request.dig(:input, 0, :content, 0)
+    expect(request[:prompt_cache_key]).to match(/\Adiscourse-chatbot:[0-9a-f]{40}\z/)
+    expect(request[:prompt_cache_options]).to eq(mode: "implicit")
+    expect(stable_content[:prompt_cache_breakpoint]).to eq(mode: "explicit")
+    expect(request.dig(:input, -1, :content, 0, :text)).to eq(
+      "The current date and time is 2026-08-16T12:00:00+00:00.",
+    )
+    expect(request).to include(tool_choice: "none")
+    expect(request[:tools]).to be_present
+    expect(response).to include(cached_tokens: 150, cache_write_tokens: 25)
+  end
+
+  it "does not send OpenAI-specific cache parameters to a custom endpoint" do
+    SiteSetting.chatbot_open_ai_model_low_trust = "gpt-5.6"
+    SiteSetting.chatbot_open_ai_model_custom_url_low_trust = "https://llm.example.com/v1"
+    bot_opts = { type: ::DiscourseChatbot::POST, topic_or_channel_id: 42, trust_level: "low" }
+    bot = described_class.new(bot_opts)
+
+    parameters =
+      bot.responses_parameters(
+        [{ role: "developer", content: "Stable", prompt_cache_breakpoint: true }],
+      )
+
+    expect(parameters).not_to have_key(:prompt_cache_key)
+    expect(parameters).not_to have_key(:prompt_cache_options)
+    expect(parameters.dig(:input, 0, :content, 0)).to eq(type: "input_text", text: "Stable")
   end
 
   it "requires a tool during the first iteration when configured" do
@@ -771,8 +879,10 @@ describe ::DiscourseChatbot::Bot do
       ],
     )
     expect(requests.second[:max_completion_tokens]).to eq(96)
-    expect(requests.second).not_to have_key(:tools)
-    expect(requests.third).not_to have_key(:tools)
+    expect(requests.second).to include(tool_choice: "none")
+    expect(requests.second[:tools]).to be_present
+    expect(requests.third).to include(tool_choice: "none")
+    expect(requests.third[:tools]).to be_present
   end
 
   it "records when a review passes and retains the first answer" do
@@ -826,7 +936,8 @@ describe ::DiscourseChatbot::Bot do
         },
       ],
     )
-    expect(requests.second).not_to have_key(:tools)
+    expect(requests.second).to include(tool_choice: "none")
+    expect(requests.second[:tools]).to be_present
     expect(requests.third[:max_completion_tokens]).to eq(8)
     expect(requests.third[:messages].last[:content]).to include(
       JSON.generate(A: "Candidate A", B: "Candidate B"),
@@ -1092,8 +1203,10 @@ describe ::DiscourseChatbot::Bot do
     expect(response[:reply]).to eq("Candidate B")
     expect(requests.first).to have_key(:tools)
     expect(requests.second).to have_key(:tools)
-    expect(requests.third).not_to have_key(:tools)
-    expect(requests.fourth).not_to have_key(:tools)
+    expect(requests.third).to include(tool_choice: "none")
+    expect(requests.third[:tools]).to be_present
+    expect(requests.fourth).to include(tool_choice: "none")
+    expect(requests.fourth[:tools]).to be_present
     expect(response[:inner_thoughts]).to eq(
       [
         {
@@ -1535,7 +1648,8 @@ describe ::DiscourseChatbot::Bot do
 
     expect(response[:reply]).to eq("The answer is 4.")
     expect(requests.first).to have_key(:tools)
-    expect(requests.last).not_to have_key(:tools)
+    expect(requests.last).to include(tool_choice: "none")
+    expect(requests.last[:tools]).to eq(requests.first[:tools])
   end
 
   it "raises a non-retryable error after exhausting response iterations" do
@@ -1759,6 +1873,16 @@ describe ::DiscourseChatbot::Bot, "#merge_tools" do
     tool_mapping = rag.instance_variable_get(:@tool_mapping)
 
     expect(tool_mapping).to have_key("wikipedia")
+  end
+
+  it "orders extension tools by name" do
+    enable_tools.call
+    build_extension_tool.call("zeta")
+    build_extension_tool.call("alpha")
+
+    tool_definitions = described_class.new({}).instance_variable_get(:@tool_definitions)
+
+    expect(tool_definitions.map { |tool| tool["name"] }).to eq(%w[alpha zeta])
   end
 
   it "excludes tools that are not selected" do

--- a/spec/lib/bot_spec.rb
+++ b/spec/lib/bot_spec.rb
@@ -91,8 +91,6 @@ describe ::DiscourseChatbot::Bot do
   end
 
   it "calls a tool on returning a tool request from LLN" do
-    DateTime.expects(:current).returns("2023-08-18T10:11:44+00:00")
-
     query = [{ role: "user", content: "merefield said what is 3 * 23.452432?" }]
 
     system_entry = {
@@ -100,15 +98,8 @@ describe ::DiscourseChatbot::Bot do
       content:
         "You are a helpful assistant. You have tools that give you the power to get newer information. Only use the tools you have been provided with. When referring to users by name, include an @ symbol directly in front of their username. Only respond to the last question, using the prior information as context, if appropriate.",
     }
-    date_entry = {
-      role: "developer",
-      content: "The current date and time is 2023-08-18T10:11:44+00:00.",
-    }
-
-    first_query =
-      get_chatbot_input_fixture("llm_first_query").unshift(system_entry).push(date_entry)
+    first_query = get_chatbot_input_fixture("llm_first_query").unshift(system_entry)
     second_query = get_chatbot_input_fixture("llm_second_query").unshift(system_entry)
-    second_query.insert(2, date_entry)
 
     described_class
       .any_instance
@@ -129,7 +120,6 @@ describe ::DiscourseChatbot::Bot do
   it "optimizes official Chat Completions requests for prompt caching" do
     SiteSetting.chatbot_open_ai_model_low_trust = "gpt-4.1-mini"
     SiteSetting.chatbot_chain_of_thought_max_iterations = 1
-    DateTime.stubs(:current).returns("2026-08-16T12:00:00+00:00")
     request = nil
     bot_opts = { type: ::DiscourseChatbot::POST, topic_or_channel_id: 42, trust_level: "low" }
 
@@ -154,9 +144,11 @@ describe ::DiscourseChatbot::Bot do
       described_class.new(bot_opts).get_response([{ role: "user", content: "Help me" }], bot_opts)
 
     expect(request[:prompt_cache_key]).to match(/\Adiscourse-chatbot:[0-9a-f]{40}\z/)
-    expect(request[:messages].first[:content]).not_to include("current date")
-    expect(request[:messages].last[:content]).to eq(
-      "The current date and time is 2026-08-16T12:00:00+00:00.",
+    expect(request[:messages]).to eq(
+      [
+        { role: "developer", content: I18n.t("chatbot.prompt.system.rag.open") },
+        { role: "user", content: "Help me" },
+      ],
     )
     expect(request).to include(tool_choice: "none")
     expect(request[:tools]).to be_present
@@ -166,7 +158,6 @@ describe ::DiscourseChatbot::Bot do
   it "uses an explicit stable-prefix breakpoint for GPT-5.6 Responses requests" do
     SiteSetting.chatbot_open_ai_model_low_trust = "gpt-5.6"
     SiteSetting.chatbot_chain_of_thought_max_iterations = 1
-    DateTime.stubs(:current).returns("2026-08-16T12:00:00+00:00")
     request = nil
     bot_opts = {
       type: ::DiscourseChatbot::MESSAGE,
@@ -204,12 +195,35 @@ describe ::DiscourseChatbot::Bot do
     expect(request[:prompt_cache_key]).to match(/\Adiscourse-chatbot:[0-9a-f]{40}\z/)
     expect(request[:prompt_cache_options]).to eq(mode: "implicit")
     expect(stable_content[:prompt_cache_breakpoint]).to eq(mode: "explicit")
-    expect(request.dig(:input, -1, :content, 0, :text)).to eq(
-      "The current date and time is 2026-08-16T12:00:00+00:00.",
-    )
+    expect(request.dig(:input, -1, :content, 0, :text)).to eq("Help me")
     expect(request).to include(tool_choice: "none")
     expect(request[:tools]).to be_present
     expect(response).to include(cached_tokens: 150, cache_write_tokens: 25)
+  end
+
+  it "places a date-only context before the conversation when calculate is unavailable" do
+    SiteSetting.chatbot_tools_low_trust = ""
+    Date.stubs(:current).returns(Date.new(2026, 8, 16))
+    request = nil
+
+    client
+      .expects(:chat)
+      .with do |args|
+        request = args[:parameters]
+        true
+      end
+      .returns(completion_response.call("Done"))
+
+    response = described_class.new({}).get_response([{ role: "user", content: "Help me" }], {})
+
+    expect(response[:reply]).to eq("Done")
+    expect(request[:messages]).to eq(
+      [
+        { role: "developer", content: I18n.t("chatbot.prompt.system.rag.open") },
+        { role: "developer", content: "The current date is 2026-08-16." },
+        { role: "user", content: "Help me" },
+      ],
+    )
   end
 
   it "does not send OpenAI-specific cache parameters to a custom endpoint" do


### PR DESCRIPTION
Previously, changing timestamps, removed tool schemas, nondeterministic extension ordering, and absent cache routing metadata reduced prompt-cache reuse, while a trailing date message could distract the model from the user’s request.

This change creates stable prompt prefixes for Responses and Chat Completions, adds conversation-scoped cache keys and GPT-5.6 breakpoints for official OpenAI endpoints, preserves tool schemas with `tool_choice: "none"`, records cache-token usage, relies on the calculator’s `NOW` support when available, supplies an early date-only fallback otherwise, and is validated by plugin lint plus 86 focused examples.
