### PR TITLE
FIX: Accept common current-time calculator syntax

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -180,19 +180,20 @@ en:
           error: "I couldn't save any information about %{user_field} for answer '%{answer}'"
         calculator:
           description: |
-            Evaluate one expression using Dentaku formula syntax, not Ruby syntax. Use this tool for arithmetic, comparisons, mathematical functions, and calculations involving the current date or time. Always call this tool with `NOW` when asked for the current date or time; never infer the current date or time yourself.
+            Evaluate one expression using Dentaku formula syntax. Use this tool for arithmetic, comparisons, mathematical functions, and calculations involving the current date or time. Always call this tool with `NOW` when asked for the current date or time; never infer the current date or time yourself.
 
             Formula syntax requirements:
             - Syntax is case-insensitive. Use operators such as `+`, `-`, `*`, `/`, `%`, `=`, `!=`, `<`, `<=`, `>`, and `>=`.
             - Use functions such as `ABS`, `ROUND`, `MIN`, `MAX`, `SUM`, `SQRT`, `CBRT`, and `IF(condition, true_value, false_value)`.
             - Use the predefined variables `PI`, `E`, and `NOW`. Other variables are not available.
             - Use `DURATION(number, unit)` for calendar offsets. The unit must be `day`, `days`, `month`, `months`, `year`, or `years` without quotes.
-            - Ruby code, method calls, assignments, exponentiation, and bit shifting are not supported.
+            - Use only the operators, functions, variables, and duration syntax listed above.
             - Submit only the expression to evaluate.
 
             If the expression is rejected, retry once using the supported syntax. Do not repeat the same invalid expression unchanged. If it cannot be corrected, continue without the calculation and do not treat the error as a result.
 
             Usage:
+              Action Input: NOW
               Action Input: 1 + 1
               Action Input: 3.0 * 2 / 4
               Action Input: 9 - 7

--- a/lib/discourse_chatbot/calculator.rb
+++ b/lib/discourse_chatbot/calculator.rb
@@ -59,7 +59,11 @@ module DiscourseChatbot
     end
 
     def normalize_expression(expression)
-      expression.gsub(/\bMath(?:::|\.)PI\b/i, "PI").gsub(/\bMath(?:::|\.)E\b/i, "E").gsub("π", "PI")
+      expression
+        .gsub(/\bMath(?:::|\.)PI\b/i, "PI")
+        .gsub(/\bMath(?:::|\.)E\b/i, "E")
+        .gsub(/\b(?:Time|DateTime)\.(?:now|current)\b/i, "NOW")
+        .gsub("π", "PI")
     end
 
     def validate_tokens!(tokens)

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Chat, Topics and Private Messages
-# version: 2.4.2
+# version: 2.4.3
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/calculator_spec.rb
+++ b/spec/lib/calculator_spec.rb
@@ -13,11 +13,15 @@ RSpec.describe DiscourseChatbot::Calculator do
       expect(described_class.evaluate("NOW - DURATION(2, days)", now:)).to eq(now - 2.days)
     end
 
-    it "normalizes common aliases for mathematical constants" do
+    it "normalizes common model-generated aliases" do
+      now = Time.zone.parse("2026-08-16 17:30:00")
+
       expect(described_class.evaluate("3 * Math::PI")).to be_within(0.000_001).of(3 * Math::PI)
       expect(described_class.evaluate("Math.PI + Math::E + Math.E + π")).to be_within(0.000_001).of(
         2 * Math::PI + 2 * Math::E,
       )
+      expect(described_class.evaluate("Time.now", now:)).to eq(now)
+      expect(described_class.evaluate("DateTime.current", now:)).to eq(now)
     end
 
     it "rejects Ruby code and host resource access" do


### PR DESCRIPTION
Previously, current-time requests could fail when a model sent a familiar dotted time alias such as `Time.now`, even though the calculator accepts Dentaku's `NOW` variable.

This change uses positive Dentaku-only tool guidance, normalizes safe common current-time aliases to `NOW`, adds a direct `NOW` example, and bumps the plugin version to 2.4.3; the calculator, tool, and bot specs pass.
