### PR TITLE
FEATURE: Add usage statistics to inner-thought audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ These strategies have several safeguards:
 * Usable partial responses produced at the configured completion length limit are returned without additional reasoning.
 * If optional reasoning fails, exceeds its available budget, produces malformed control output, or proposes an invalid answer, the already-valid first answer is returned.
 
-The staff-visible inner-thoughts trace records tool calls, the selected advanced strategy, compact review, confidence, and selection information, and the final outcome in chronological order, including safe fallbacks. It does not request or expose a model's hidden chain-of-thought.
+The staff-visible inner-thoughts trace records tool calls, the selected advanced strategy, compact review, confidence, and selection information, and the final outcome in chronological order, including safe fallbacks. It also includes aggregate input, output, cache, and provider-reported reasoning token statistics for the complete response. These statistics are accumulated outside the model context and are only merged into the persisted audit entry after generation finishes. It does not request or expose a model's hidden chain-of-thought.
 
 ### Token, tool, and URL limits
 

--- a/app/jobs/regular/chatbot_reply.rb
+++ b/app/jobs/regular/chatbot_reply.rb
@@ -157,6 +157,9 @@ class ::Jobs::ChatbotReply < Jobs::Base
           end
         reply_and_thoughts[:reply] = I18n.t(error_key)
         reply_and_thoughts[:inner_thoughts] = bot.inner_thoughts if bot.respond_to?(:inner_thoughts)
+        if bot.respond_to?(:usage_statistics)
+          reply_and_thoughts[:usage_statistics] = bot.usage_statistics
+        end
       rescue => e
         Rails.logger.error("Chatbot: There was a problem, but will retry til limit: #{e}")
         fail e

--- a/lib/discourse_chatbot/bot.rb
+++ b/lib/discourse_chatbot/bot.rb
@@ -48,6 +48,8 @@ module ::DiscourseChatbot
       @total_tokens = 0
       @cached_tokens = 0
       @cache_write_tokens = 0
+      @usage_totals = Hash.new(0)
+      @reported_usage_fields = {}
       @enabled_tool_names = configured_tool_names(opts[:trust_level])
       if tools
         merge_tools(opts)
@@ -65,6 +67,36 @@ module ::DiscourseChatbot
 
     def inner_thoughts
       Array(@initial_inner_thoughts) + Array(@inner_thoughts)
+    end
+
+    def usage_statistics
+      return if @reported_usage_fields.empty?
+
+      statistics = { type: "usage_statistics", model: @model_name }
+      statistics[:input_tokens] = @usage_totals[:input_tokens] if usage_field_reported?(
+        :input_tokens,
+      )
+      if usage_field_reported?(:cached_input_tokens)
+        statistics[:cached_input_tokens] = @usage_totals[:cached_input_tokens]
+        if @usage_totals[:input_tokens].positive?
+          statistics[:cached_input_percentage] = (
+            @usage_totals[:cached_input_tokens].to_f / @usage_totals[:input_tokens] * 100
+          ).round(1)
+        end
+      end
+      if usage_field_reported?(:cache_write_tokens)
+        statistics[:cache_write_tokens] = @usage_totals[:cache_write_tokens]
+      end
+      statistics[:output_tokens] = @usage_totals[:output_tokens] if usage_field_reported?(
+        :output_tokens,
+      )
+      if usage_field_reported?(:reasoning_tokens)
+        statistics[:reasoning_tokens] = @usage_totals[:reasoning_tokens]
+      end
+      statistics[:total_tokens] = @usage_totals[:total_tokens] if usage_field_reported?(
+        :total_tokens,
+      )
+      statistics
     end
 
     def ask(opts)
@@ -157,6 +189,7 @@ module ::DiscourseChatbot
       {
         reply: res["choices"][0]["message"]["content"],
         inner_thoughts: inner_thoughts,
+        usage_statistics: usage_statistics,
         total_tokens: @total_tokens,
         cached_tokens: @cached_tokens,
         cache_write_tokens: @cache_write_tokens,
@@ -565,16 +598,29 @@ module ::DiscourseChatbot
 
     def track_token_usage(usage)
       usage = usage.to_h.with_indifferent_access
-      @total_tokens += usage[:total_tokens].to_i
+      input_tokens = usage[:input_tokens] || usage[:prompt_tokens]
+      output_tokens = usage[:output_tokens] || usage[:completion_tokens]
+      total_tokens = usage[:total_tokens]
       cache_details = usage[:input_tokens_details] || usage[:prompt_tokens_details] || {}
       cache_details = cache_details.with_indifferent_access
-      cached_tokens = cache_details[:cached_tokens].to_i
-      cache_write_tokens = cache_details[:cache_write_tokens].to_i
-      @cached_tokens += cached_tokens
-      @cache_write_tokens += cache_write_tokens
+      output_details = usage[:output_tokens_details] || usage[:completion_tokens_details] || {}
+      output_details = output_details.with_indifferent_access
+      cached_tokens = cache_details[:cached_tokens]
+      cache_write_tokens = cache_details[:cache_write_tokens]
+
+      record_usage_stat(:input_tokens, input_tokens)
+      record_usage_stat(:cached_input_tokens, cached_tokens)
+      record_usage_stat(:cache_write_tokens, cache_write_tokens)
+      record_usage_stat(:output_tokens, output_tokens)
+      record_usage_stat(:reasoning_tokens, output_details[:reasoning_tokens])
+      record_usage_stat(:total_tokens, total_tokens)
+
+      @total_tokens += total_tokens.to_i
+      @cached_tokens += cached_tokens.to_i
+      @cache_write_tokens += cache_write_tokens.to_i
 
       ::DiscourseChatbot.progress_debug_message(
-        "Prompt cache usage: cached #{cached_tokens} tokens, wrote #{cache_write_tokens} tokens",
+        "Prompt cache usage: cached #{cached_tokens.to_i} tokens, wrote #{cache_write_tokens.to_i} tokens",
       )
     end
 
@@ -1129,6 +1175,17 @@ module ::DiscourseChatbot
     end
 
     private
+
+    def record_usage_stat(name, value)
+      return if value.nil?
+
+      @reported_usage_fields[name] = true
+      @usage_totals[name] += value.to_i
+    end
+
+    def usage_field_reported?(name)
+      @reported_usage_fields[name]
+    end
 
     def image_url?(string)
       # Regular expression to find URLs

--- a/lib/discourse_chatbot/post/post_reply_creator.rb
+++ b/lib/discourse_chatbot/post/post_reply_creator.rb
@@ -35,10 +35,12 @@ module DiscourseChatbot
                SiteSetting.chatbot_include_inner_thoughts_in_private_messages && @is_private_msg ||
                  SiteSetting.chatbot_include_inner_thoughts_in_topics && !@is_private_msg
              )
+            audit_entries = Array(@inner_thoughts)
+            audit_entries << @usage_statistics if @usage_statistics.present?
             default_opts.merge!(
               raw:
                 ::DiscourseChatbot::INNER_THOUGHTS_POST_PREFIX +
-                  JSON.pretty_generate(@inner_thoughts) + "\n```\n[/details]",
+                  JSON.pretty_generate(audit_entries) + "\n```\n[/details]",
             )
             if SiteSetting.chatbot_include_inner_thoughts_in_topics_as_whisper && !@is_private_msg
               default_opts.merge!(post_type: ::Post.types[:whisper])

--- a/lib/discourse_chatbot/reply_creator.rb
+++ b/lib/discourse_chatbot/reply_creator.rb
@@ -14,6 +14,7 @@ module ::DiscourseChatbot
       @private = options[:private]
       @human_participants_count = options[:human_participants_count]
       @inner_thoughts = options[:inner_thoughts]
+      @usage_statistics = options[:usage_statistics]
       @trust_level = options[:trust_level]
       @blocked_question = options[:blocked_question]
       @message_body = I18n.t("chatbot.errors.retries") if @message_body.blank?

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Chat, Topics and Private Messages
-# version: 2.4.3
+# version: 2.4.4
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/jobs/regular/chatbot_reply_spec.rb
+++ b/spec/jobs/regular/chatbot_reply_spec.rb
@@ -170,4 +170,53 @@ RSpec.describe Jobs::ChatbotReply do
     )
     expect(replies.last.raw).to eq("A normal RAG answer")
   end
+
+  it "persists usage statistics outside future model context" do
+    SiteSetting.chatbot_include_inner_thoughts_in_private_messages = true
+    statistics = {
+      type: "usage_statistics",
+      model: "gpt-5.6",
+      input_tokens: 200,
+      cached_input_tokens: 150,
+      cached_input_percentage: 75.0,
+      output_tokens: 40,
+      reasoning_tokens: 10,
+      total_tokens: 240,
+    }
+    post = PostCreator.create!(requester, topic_id: pm_topic.id, raw: "Hello @#{bot_user.username}")
+    opts = ::DiscourseChatbot::Post::PostEvaluation.new.trigger_response(post)
+    opts[:trust_level] = "low"
+
+    ::DiscourseChatbot::Bot
+      .any_instance
+      .stubs(:ask)
+      .returns(
+        {
+          reply: "A measured response",
+          inner_thoughts: [],
+          usage_statistics: statistics,
+          total_tokens: 240,
+        },
+      )
+
+    described_class.new.execute(opts)
+
+    replies = pm_topic.posts.order(:post_number).last(2)
+    audit_post = replies.first
+    expect(JSON.parse(audit_post.raw[/```json\n(.*)\n```/m, 1])).to eq(
+      [statistics.deep_stringify_keys],
+    )
+    expect(replies.last.raw).to eq("A measured response")
+
+    follow_up = PostCreator.create!(requester, topic_id: pm_topic.id, raw: "Tell me more")
+    prompt =
+      ::DiscourseChatbot::Post::PostPromptUtils.create_prompt(
+        reply_to_message_or_post_id: follow_up.id,
+        original_post_number: follow_up.post_number,
+        bot_user_id: bot_user.id,
+        category_id: pm_topic.category_id,
+      )
+
+    expect(JSON.generate(prompt)).not_to include(audit_post.raw)
+  end
 end

--- a/spec/lib/bot_spec.rb
+++ b/spec/lib/bot_spec.rb
@@ -117,6 +117,85 @@ describe ::DiscourseChatbot::Bot do
     )
   end
 
+  it "aggregates usage statistics without adding them to the active model context" do
+    SiteSetting.chatbot_open_ai_model_low_trust = "gpt-4.1-mini"
+    requests = []
+
+    client
+      .expects(:chat)
+      .times(2)
+      .with do |args|
+        requests << args[:parameters]
+        true
+      end
+      .returns(
+        {
+          "choices" => [
+            {
+              "finish_reason" => "tool_calls",
+              "message" => {
+                "content" => "",
+                "tool_calls" => [
+                  {
+                    "id" => "call_1",
+                    "type" => "function",
+                    "function" => {
+                      "name" => "calculate",
+                      "arguments" => '{"input":"2 + 2"}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          "usage" => {
+            "prompt_tokens" => 100,
+            "completion_tokens" => 10,
+            "total_tokens" => 110,
+            "prompt_tokens_details" => {
+              "cached_tokens" => 60,
+              "cache_write_tokens" => 20,
+            },
+          },
+        },
+        {
+          "choices" => [
+            { "finish_reason" => "stop", "message" => { "content" => "The answer is 4." } },
+          ],
+          "usage" => {
+            "prompt_tokens" => 150,
+            "completion_tokens" => 20,
+            "total_tokens" => 170,
+            "prompt_tokens_details" => {
+              "cached_tokens" => 100,
+            },
+            "completion_tokens_details" => {
+              "reasoning_tokens" => 5,
+            },
+          },
+        },
+      )
+
+    response = rag.get_response([{ role: "user", content: "What is 2 + 2?" }], opts)
+    statistics = response[:usage_statistics]
+
+    expect(statistics).to eq(
+      {
+        type: "usage_statistics",
+        model: rag.model_name,
+        input_tokens: 250,
+        cached_input_tokens: 160,
+        cached_input_percentage: 64.0,
+        cache_write_tokens: 20,
+        output_tokens: 30,
+        reasoning_tokens: 5,
+        total_tokens: 280,
+      },
+    )
+    expect(JSON.generate(requests.second[:messages])).not_to include(statistics[:type])
+    expect(JSON.generate(response[:inner_thoughts])).not_to include(statistics[:type])
+  end
+
   it "optimizes official Chat Completions requests for prompt caching" do
     SiteSetting.chatbot_open_ai_model_low_trust = "gpt-4.1-mini"
     SiteSetting.chatbot_chain_of_thought_max_iterations = 1
@@ -130,8 +209,10 @@ describe ::DiscourseChatbot::Bot do
         true
       end
       .returns(
-        completion_response.call("Done").deep_merge(
+        completion_response.call("Done", total_tokens: 250).deep_merge(
           "usage" => {
+            "prompt_tokens" => 200,
+            "completion_tokens" => 50,
             "prompt_tokens_details" => {
               "cached_tokens" => 120,
               "cache_write_tokens" => 30,
@@ -153,6 +234,14 @@ describe ::DiscourseChatbot::Bot do
     expect(request).to include(tool_choice: "none")
     expect(request[:tools]).to be_present
     expect(response).to include(cached_tokens: 120, cache_write_tokens: 30)
+    expect(response[:usage_statistics]).to include(
+      input_tokens: 200,
+      cached_input_tokens: 120,
+      cached_input_percentage: 60.0,
+      cache_write_tokens: 30,
+      output_tokens: 50,
+      total_tokens: 250,
+    )
   end
 
   it "uses an explicit stable-prefix breakpoint for GPT-5.6 Responses requests" do
@@ -180,9 +269,14 @@ describe ::DiscourseChatbot::Bot do
           ],
           "usage" => {
             "total_tokens" => 200,
+            "input_tokens" => 180,
+            "output_tokens" => 20,
             "input_tokens_details" => {
               "cached_tokens" => 150,
               "cache_write_tokens" => 25,
+            },
+            "output_tokens_details" => {
+              "reasoning_tokens" => 12,
             },
           },
         },
@@ -199,6 +293,15 @@ describe ::DiscourseChatbot::Bot do
     expect(request).to include(tool_choice: "none")
     expect(request[:tools]).to be_present
     expect(response).to include(cached_tokens: 150, cache_write_tokens: 25)
+    expect(response[:usage_statistics]).to include(
+      input_tokens: 180,
+      cached_input_tokens: 150,
+      cached_input_percentage: 83.3,
+      cache_write_tokens: 25,
+      output_tokens: 20,
+      reasoning_tokens: 12,
+      total_tokens: 200,
+    )
   end
 
   it "places a date-only context before the conversation when calculate is unavailable" do


### PR DESCRIPTION
Previously, staff inner-thought audits omitted provider token and cache statistics, while adding telemetry to the active trace would have risked feeding it back into iterative model context.

This change aggregates Chat Completions and Responses usage separately from model context, appends the final statistics only to the persisted audit, preserves their exclusion from future prompts, and bumps the plugin to 2.4.4; lint and 83 focused specs pass, while the full suite has 179 passes plus the existing unrelated site-setting defaults failure.
