### PR TITLE
FIX: Serialize blocked question defaults as JSON

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -536,31 +536,21 @@ plugins:
   chatbot_blocked_question_examples:
     client: false
     type: objects
-    default:
-      - category: Politics
-        example_question: "Who should I vote for in the next election?"
-      - category: Politics
-        example_question: "Which political party has the best policies?"
-      - category: Politics
-        example_question: "What do you think of the current government?"
-      - category: Politics
-        example_question: "Do you support the current president or prime minister?"
-      - category: Politics
-        example_question: "Will the opposition win the next election?"
-      - category: Politics
-        example_question: "Which political candidate do you prefer?"
-      - category: Video Games
-        example_question: "What video game should I play next?"
-      - category: Video Games
-        example_question: "Which games console should I buy?"
-      - category: Video Games
-        example_question: "Is PlayStation better than Xbox?"
-      - category: Video Games
-        example_question: "How do I beat this boss in a video game?"
-      - category: Video Games
-        example_question: "What is the best character build for this game?"
-      - category: Video Games
-        example_question: "What do you think of the latest video game release?"
+    default: >-
+      [
+        {"category":"Politics","example_question":"Who should I vote for in the next election?"},
+        {"category":"Politics","example_question":"Which political party has the best policies?"},
+        {"category":"Politics","example_question":"What do you think of the current government?"},
+        {"category":"Politics","example_question":"Do you support the current president or prime minister?"},
+        {"category":"Politics","example_question":"Will the opposition win the next election?"},
+        {"category":"Politics","example_question":"Which political candidate do you prefer?"},
+        {"category":"Video Games","example_question":"What video game should I play next?"},
+        {"category":"Video Games","example_question":"Which games console should I buy?"},
+        {"category":"Video Games","example_question":"Is PlayStation better than Xbox?"},
+        {"category":"Video Games","example_question":"How do I beat this boss in a video game?"},
+        {"category":"Video Games","example_question":"What is the best character build for this game?"},
+        {"category":"Video Games","example_question":"What do you think of the latest video game release?"}
+      ]
     depends_on:
       - chatbot_blocked_questions_enabled
     depends_behavior: hidden

--- a/spec/lib/blocked_question_matcher_spec.rb
+++ b/spec/lib/blocked_question_matcher_spec.rb
@@ -5,9 +5,9 @@ require_relative "../plugin_helper"
 RSpec.describe ::DiscourseChatbot::BlockedQuestionMatcher do
   let(:client) { mock }
 
-  it "ships multiple default questions for each default category" do
-    examples = SiteSetting.defaults[:chatbot_blocked_question_examples]
-    examples = JSON.parse(examples) if examples.is_a?(String)
+  it "ships multiple default questions as valid JSON" do
+    SiteSetting.remove_override!(:chatbot_blocked_question_examples)
+    examples = JSON.parse(SiteSetting.settings_hash[:chatbot_blocked_question_examples])
 
     expect(examples.map { |example| example["category"] }.tally).to eq(
       "Politics" => 6,


### PR DESCRIPTION
Previously, the blocked-question example default was converted to Ruby hash syntax in `SiteSetting.settings_hash`, causing SVG sprite JSON parsing to fail.

This change stores the examples as a valid JSON string and adds regression coverage for settings-hash serialization.