### PR TITLE
DEV: Refresh provider model selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Select `chatbot_embeddings_provider`, then choose the model shown for that provi
 
 Changing the embeddings provider or model automatically makes older Post and Topic-title vectors invalid. Background jobs gradually regenerate them with the new configuration, so you do not need to delete them manually.
 
+Embedding records and their search indexes use a shared 1,536-dimension storage contract. When `text-embedding-3-large` is selected, Chatbot uses OpenAI's `dimensions` parameter to request a shortened 1,536-dimension vector rather than storing the model's native 3,072-dimension output.
+
 For a custom embeddings service, set `chatbot_open_ai_embeddings_model_custom_name` and, when required, `chatbot_open_ai_embeddings_model_custom_url`. The endpoint must implement the selected provider's embeddings API shape and return exactly 1,536 dimensions.
 
 To refresh every in-scope embedding immediately, enter the container and run:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -165,6 +165,7 @@ plugins:
     default: claude-sonnet-5
     choices: &chatbot_anthropic_models
       - claude-fable-5-1
+      - claude-fable-5
       - claude-opus-5
       - claude-sonnet-5
       - claude-haiku-4-5

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -133,6 +133,7 @@ plugins:
     type: enum
     default: gpt-4.1-mini
     choices: &chatbot_open_ai_models
+      - gpt-6-astra
       - gpt-5.6
       - gpt-5.6-sol
       - gpt-5.6-terra

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -164,7 +164,7 @@ plugins:
     type: enum
     default: claude-sonnet-5
     choices: &chatbot_anthropic_models
-      - claude-fable-5
+      - claude-fable-5-1
       - claude-opus-5
       - claude-sonnet-5
       - claude-haiku-4-5
@@ -177,8 +177,9 @@ plugins:
   chatbot_google_gemini_model_high_trust:
     client: false
     type: enum
-    default: gemini-3.7-flash
+    default: gemini-3.8-flash
     choices: &chatbot_google_gemini_models
+      - gemini-3.8-flash
       - gemini-3.7-flash
       - gemini-3.6-flash
       - gemini-3.5-flash
@@ -257,7 +258,7 @@ plugins:
   chatbot_google_gemini_model_medium_trust:
     client: false
     type: enum
-    default: gemini-3.7-flash
+    default: gemini-3.8-flash
     choices: *chatbot_google_gemini_models
     depends_on:
       - chatbot_llm_provider
@@ -321,7 +322,7 @@ plugins:
   chatbot_google_gemini_model_low_trust:
     client: false
     type: enum
-    default: gemini-3.7-flash
+    default: gemini-3.8-flash
     choices: *chatbot_google_gemini_models
     depends_on:
       - chatbot_llm_provider
@@ -589,6 +590,7 @@ plugins:
     choices:
       - text-embedding-ada-002
       - text-embedding-3-small
+      - text-embedding-3-large
     depends_on:
       - chatbot_embeddings_enabled
       - chatbot_embeddings_provider
@@ -602,7 +604,6 @@ plugins:
     default: gemini-embedding-001
     choices:
       - gemini-embedding-2
-      - gemini-embedding-2-preview
       - gemini-embedding-001
     depends_on:
       - chatbot_embeddings_enabled
@@ -904,7 +905,7 @@ plugins:
   chatbot_google_gemini_vision_model:
     client: false
     type: enum
-    default: gemini-3.7-flash
+    default: gemini-3.8-flash
     choices: *chatbot_google_gemini_models
     depends_on:
       - chatbot_vision_provider
@@ -945,13 +946,11 @@ plugins:
   chatbot_support_picture_creation_model:
     client: false
     type: enum
-    default: dall-e-3
+    default: gpt-image-2
     choices:
-      - dall-e-3
-      - gpt-image-1
-      - gpt-image-1-mini
-      - gpt-image-1.5
       - gpt-image-2
+      - gpt-image-1.5
+      - gpt-image-1-mini
     depends_on:
       - chatbot_image_provider
     depends_on_values:
@@ -961,10 +960,11 @@ plugins:
   chatbot_google_gemini_image_model:
     client: false
     type: enum
-    default: gemini-2.5-flash-image
+    default: gemini-3.1-flash-image
     choices:
-      - gemini-3-pro-image-preview
-      - gemini-2.5-flash-image
+      - gemini-3.1-flash-image
+      - gemini-3.1-flash-lite-image
+      - gemini-3-pro-image
     depends_on:
       - chatbot_image_provider
     depends_on_values:

--- a/lib/discourse_chatbot/embedding_process.rb
+++ b/lib/discourse_chatbot/embedding_process.rb
@@ -9,7 +9,10 @@ module ::DiscourseChatbot
     end
 
     def self.request_parameters(input)
-      { model: ::DiscourseChatbot.embedding_model_name, input: input }
+      model_name = ::DiscourseChatbot.embedding_model_name
+      parameters = { model: model_name, input: input }
+      parameters[:dimensions] = EXPECTED_DIMENSIONS if model_name == "text-embedding-3-large"
+      parameters
     end
 
     def self.client_config

--- a/lib/discourse_chatbot/embedding_process.rb
+++ b/lib/discourse_chatbot/embedding_process.rb
@@ -11,7 +11,10 @@ module ::DiscourseChatbot
     def self.request_parameters(input)
       model_name = ::DiscourseChatbot.embedding_model_name
       parameters = { model: model_name, input: input }
-      parameters[:dimensions] = EXPECTED_DIMENSIONS if model_name == "text-embedding-3-large"
+      if SiteSetting.chatbot_embeddings_provider == "open_ai" &&
+           SiteSetting.chatbot_open_ai_embeddings_model == "text-embedding-3-large"
+        parameters[:dimensions] = EXPECTED_DIMENSIONS
+      end
       parameters
     end
 

--- a/lib/discourse_chatbot/post/post_embedding_process.rb
+++ b/lib/discourse_chatbot/post/post_embedding_process.rb
@@ -47,17 +47,8 @@ module DiscourseChatbot
       end
 
       def semantic_search(query)
-        self.setup_api
-
-        response =
-          @client.embeddings(
-            parameters: {
-              model: @model_name,
-              input: query[0..SiteSetting.chatbot_open_ai_embeddings_char_limit],
-            },
-          )
-
-        query_vector = self.class.embedding_vector(response)
+        query_vector =
+          get_embedding_from_api(query[0..SiteSetting.chatbot_open_ai_embeddings_char_limit])
 
         begin
           threshold = SiteSetting.chatbot_forum_search_tool_similarity_threshold

--- a/lib/discourse_chatbot/topic/topic_title_embedding_process.rb
+++ b/lib/discourse_chatbot/topic/topic_title_embedding_process.rb
@@ -47,17 +47,8 @@ module DiscourseChatbot
       end
 
       def semantic_search(query)
-        self.setup_api
-
-        response =
-          @client.embeddings(
-            parameters: {
-              model: @model_name,
-              input: query[0..SiteSetting.chatbot_open_ai_embeddings_char_limit],
-            },
-          )
-
-        query_vector = self.class.embedding_vector(response)
+        query_vector =
+          get_embedding_from_api(query[0..SiteSetting.chatbot_open_ai_embeddings_char_limit])
 
         begin
           threshold = SiteSetting.chatbot_forum_search_tool_similarity_threshold

--- a/plugin.rb
+++ b/plugin.rb
@@ -43,6 +43,7 @@ module ::DiscourseChatbot
   NON_POST_URL_REGEX = %r{\bhttps?:\/\/[^\s\/$.?#].[^\s)]*}
 
   REASONING_MODELS = %w[
+    gpt-6-astra
     o1
     o1-mini
     o3

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Chat, Topics and Private Messages
-# version: 3.0.0
+# version: 3.0.1
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/bot_spec.rb
+++ b/spec/lib/bot_spec.rb
@@ -2103,7 +2103,7 @@ describe ::DiscourseChatbot::Bot, "#merge_tools" do
     expect(tool_mapping).to have_key("escalate_to_staff")
   end
 
-  %w[gpt-image-1 gpt-image-1-mini gpt-image-1.5 gpt-image-2].each do |model_name|
+  %w[gpt-image-1-mini gpt-image-1.5 gpt-image-2].each do |model_name|
     it "includes paint_edit_picture for #{model_name}" do
       enable_tools.call("paint_edit_picture")
       SiteSetting.chatbot_support_picture_creation_model = model_name
@@ -2117,7 +2117,7 @@ describe ::DiscourseChatbot::Bot, "#merge_tools" do
 
   it "does not include paint_edit_picture for dall-e-3" do
     enable_tools.call("paint_edit_picture")
-    SiteSetting.chatbot_support_picture_creation_model = "dall-e-3"
+    SiteSetting.stubs(:chatbot_support_picture_creation_model).returns("dall-e-3")
 
     rag = described_class.new({})
     tool_mapping = rag.instance_variable_get(:@tool_mapping)
@@ -2128,7 +2128,7 @@ describe ::DiscourseChatbot::Bot, "#merge_tools" do
   it "keeps separately authenticated OpenAI image tools for another chat provider" do
     enable_tools.call("paint_picture", "paint_edit_picture")
     SiteSetting.chatbot_llm_provider = "google_gemini"
-    SiteSetting.chatbot_support_picture_creation_model = "gpt-image-1"
+    SiteSetting.chatbot_support_picture_creation_model = "gpt-image-2"
 
     tool_mapping = described_class.new({}).instance_variable_get(:@tool_mapping)
 

--- a/spec/lib/embedding_process_spec.rb
+++ b/spec/lib/embedding_process_spec.rb
@@ -75,6 +75,27 @@ RSpec.describe ::DiscourseChatbot::EmbeddingProcess do
     expect(described_class.new.get_embedding_from_api("A question to embed")).to eq(embedding)
   end
 
+  it "requests a storable vector size when OpenAI's large model uses a custom deployment name" do
+    SiteSetting.chatbot_embeddings_provider = "open_ai"
+    SiteSetting.chatbot_open_ai_embeddings_model = "text-embedding-3-large"
+    SiteSetting.chatbot_open_ai_embeddings_model_custom_name = "large-embedding-deployment"
+    embedding = Array.new(described_class::EXPECTED_DIMENSIONS, 0.1)
+    client = mock
+    OpenAI::Client.stubs(:new).returns(client)
+    client
+      .expects(:embeddings)
+      .with(
+        parameters: {
+          model: "large-embedding-deployment",
+          input: "A question to embed",
+          dimensions: described_class::EXPECTED_DIMENSIONS,
+        },
+      )
+      .returns({ "data" => [{ "embedding" => embedding }] })
+
+    expect(described_class.new.get_embedding_from_api("A question to embed")).to eq(embedding)
+  end
+
   it "rejects vectors that cannot be stored in the existing embedding columns" do
     client = mock
     OpenAI::Client.stubs(:new).returns(client)

--- a/spec/lib/embedding_process_spec.rb
+++ b/spec/lib/embedding_process_spec.rb
@@ -55,6 +55,26 @@ RSpec.describe ::DiscourseChatbot::EmbeddingProcess do
     expect(described_class.new.get_embedding_from_api("A question to embed")).to eq(embedding)
   end
 
+  it "requests a storable vector size from OpenAI's large embedding model" do
+    SiteSetting.chatbot_embeddings_provider = "open_ai"
+    SiteSetting.chatbot_open_ai_embeddings_model = "text-embedding-3-large"
+    embedding = Array.new(described_class::EXPECTED_DIMENSIONS, 0.1)
+    client = mock
+    OpenAI::Client.stubs(:new).returns(client)
+    client
+      .expects(:embeddings)
+      .with(
+        parameters: {
+          model: "text-embedding-3-large",
+          input: "A question to embed",
+          dimensions: described_class::EXPECTED_DIMENSIONS,
+        },
+      )
+      .returns({ "data" => [{ "embedding" => embedding }] })
+
+    expect(described_class.new.get_embedding_from_api("A question to embed")).to eq(embedding)
+  end
+
   it "rejects vectors that cannot be stored in the existing embedding columns" do
     client = mock
     OpenAI::Client.stubs(:new).returns(client)

--- a/spec/lib/llm_client_spec.rb
+++ b/spec/lib/llm_client_spec.rb
@@ -29,6 +29,12 @@ describe ::DiscourseChatbot::LlmClient do
     end
   end
 
+  it "uses the reasoning-model request path for GPT-6 Astra" do
+    SiteSetting.chatbot_open_ai_model_low_trust = "gpt-6-astra"
+
+    expect(described_class.new(trust_level: "low")).to be_reasoning_model
+  end
+
   it "uses Anthropic's compatibility endpoint and default model" do
     SiteSetting.chatbot_llm_provider = "anthropic"
 

--- a/spec/lib/llm_client_spec.rb
+++ b/spec/lib/llm_client_spec.rb
@@ -84,7 +84,7 @@ describe ::DiscourseChatbot::LlmClient do
         "https://generativelanguage.googleapis.com/v1beta/openai/",
       )
       expect(llm_client.client.access_token).to eq("gemini-token")
-      expect(llm_client.model_name).to eq("gemini-3.7-flash")
+      expect(llm_client.model_name).to eq("gemini-3.8-flash")
       expect(llm_client.chat_completions_generation_parameters).to eq({})
       expect(parameters[:messages]).to eq([{ role: "system", content: "You are helpful" }])
     end

--- a/spec/lib/post_embedding_process_spec.rb
+++ b/spec/lib/post_embedding_process_spec.rb
@@ -74,4 +74,16 @@ RSpec.describe DiscourseChatbot::Post::PostEmbeddingProcess do
       expect(embedding_process.is_valid(post.id)).to eq(true)
     end
   end
+
+  describe "semantic search" do
+    it "uses the dimension-aware embedding request path" do
+      SiteSetting.chatbot_forum_search_tool_hybrid_search = false
+      SiteSetting.chatbot_open_ai_embeddings_char_limit = 10
+      embedding = Array.new(::DiscourseChatbot::EmbeddingProcess::EXPECTED_DIMENSIONS, 0.1)
+      embedding_process.expects(:get_embedding_from_api).with("A long sear").returns(embedding)
+      DB.expects(:query).returns([])
+
+      expect(embedding_process.semantic_search("A long search query")).to eq([])
+    end
+  end
 end

--- a/spec/lib/site_setting_dependencies_spec.rb
+++ b/spec/lib/site_setting_dependencies_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe SiteSetting do
       %w[gpt-image-2 gpt-image-1.5 gpt-image-1-mini],
     )
     expect(model_choices.call(:chatbot_anthropic_model_high_trust)).to eq(
-      %w[claude-fable-5-1 claude-opus-5 claude-sonnet-5 claude-haiku-4-5],
+      %w[claude-fable-5-1 claude-fable-5 claude-opus-5 claude-sonnet-5 claude-haiku-4-5],
     )
     expect(model_choices.call(:chatbot_google_gemini_model_high_trust)).to eq(
       %w[

--- a/spec/lib/site_setting_dependencies_spec.rb
+++ b/spec/lib/site_setting_dependencies_spec.rb
@@ -185,18 +185,45 @@ RSpec.describe SiteSetting do
     end
   end
 
-  it "lists current chat models for every provider" do
+  it "lists current models for every provider" do
     model_choices = lambda { |setting| settings.fetch(setting)[:valid_values].pluck(:value) }
 
-    expect(model_choices.call(:chatbot_open_ai_model_high_trust)).to include(
-      "gpt-5.6",
-      "gpt-4.1-mini",
+    expect(model_choices.call(:chatbot_open_ai_model_high_trust)).to eq(
+      %w[
+        gpt-5.6
+        gpt-5.6-sol
+        gpt-5.6-terra
+        gpt-5.6-luna
+        gpt-5.5
+        gpt-5.5-pro
+        gpt-5.4
+        gpt-5.4-pro
+        gpt-5.4-mini
+        gpt-5.4-nano
+        gpt-5.2
+        gpt-5.2-pro
+        gpt-5.1
+        gpt-5
+        gpt-5-pro
+        gpt-5-mini
+        gpt-5-nano
+        gpt-4.1
+        gpt-4.1-mini
+        gpt-4.1-nano
+      ],
+    )
+    expect(model_choices.call(:chatbot_open_ai_embeddings_model)).to eq(
+      %w[text-embedding-ada-002 text-embedding-3-small text-embedding-3-large],
+    )
+    expect(model_choices.call(:chatbot_support_picture_creation_model)).to eq(
+      %w[gpt-image-2 gpt-image-1.5 gpt-image-1-mini],
     )
     expect(model_choices.call(:chatbot_anthropic_model_high_trust)).to eq(
-      %w[claude-fable-5 claude-opus-5 claude-sonnet-5 claude-haiku-4-5],
+      %w[claude-fable-5-1 claude-opus-5 claude-sonnet-5 claude-haiku-4-5],
     )
     expect(model_choices.call(:chatbot_google_gemini_model_high_trust)).to eq(
       %w[
+        gemini-3.8-flash
         gemini-3.7-flash
         gemini-3.6-flash
         gemini-3.5-flash
@@ -209,8 +236,35 @@ RSpec.describe SiteSetting do
         gemini-2.5-flash-lite
       ],
     )
+    expect(model_choices.call(:chatbot_google_gemini_embeddings_model)).to eq(
+      %w[gemini-embedding-2 gemini-embedding-001],
+    )
+    expect(model_choices.call(:chatbot_google_gemini_image_model)).to eq(
+      %w[gemini-3.1-flash-image gemini-3.1-flash-lite-image gemini-3-pro-image],
+    )
     expect(model_choices.call(:chatbot_x_ai_model_high_trust)).to eq(
       %w[grok-4.6 grok-4.5 grok-4.3 grok-build-0.1 grok-4.20-reasoning grok-4.20-non-reasoning],
+    )
+  end
+
+  it "uses current provider model defaults" do
+    defaults =
+      %i[
+        chatbot_google_gemini_model_high_trust
+        chatbot_google_gemini_model_medium_trust
+        chatbot_google_gemini_model_low_trust
+        chatbot_google_gemini_vision_model
+        chatbot_google_gemini_image_model
+        chatbot_support_picture_creation_model
+      ].to_h { |setting| [setting, settings.fetch(setting)[:default]] }
+
+    expect(defaults).to eq(
+      chatbot_google_gemini_model_high_trust: "gemini-3.8-flash",
+      chatbot_google_gemini_model_medium_trust: "gemini-3.8-flash",
+      chatbot_google_gemini_model_low_trust: "gemini-3.8-flash",
+      chatbot_google_gemini_vision_model: "gemini-3.8-flash",
+      chatbot_google_gemini_image_model: "gemini-3.1-flash-image",
+      chatbot_support_picture_creation_model: "gpt-image-2",
     )
   end
 

--- a/spec/lib/site_setting_dependencies_spec.rb
+++ b/spec/lib/site_setting_dependencies_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe SiteSetting do
 
     expect(model_choices.call(:chatbot_open_ai_model_high_trust)).to eq(
       %w[
+        gpt-6-astra
         gpt-5.6
         gpt-5.6-sol
         gpt-5.6-terra

--- a/spec/lib/tools/paint_spec.rb
+++ b/spec/lib/tools/paint_spec.rb
@@ -44,7 +44,7 @@ describe ::DiscourseChatbot::Tools::Paint do
   describe ".image_edit_supported?" do
     it "supports OpenAI GPT Image and xAI, but not Gemini image models" do
       SiteSetting.chatbot_image_provider = "open_ai"
-      SiteSetting.chatbot_support_picture_creation_model = "gpt-image-1"
+      SiteSetting.chatbot_support_picture_creation_model = "gpt-image-2"
       expect(described_class.image_edit_supported?).to eq(true)
 
       SiteSetting.chatbot_image_provider = "x_ai"

--- a/spec/lib/topic_title_embedding_process_spec.rb
+++ b/spec/lib/topic_title_embedding_process_spec.rb
@@ -23,4 +23,13 @@ RSpec.describe DiscourseChatbot::Topic::TopicTitleEmbeddingProcess do
 
     expect(embedding_process.is_valid(topic.id)).to eq(true)
   end
+
+  it "uses the dimension-aware embedding request path for semantic search" do
+    SiteSetting.chatbot_open_ai_embeddings_char_limit = 10
+    embedding = Array.new(::DiscourseChatbot::EmbeddingProcess::EXPECTED_DIMENSIONS, 0.1)
+    embedding_process.expects(:get_embedding_from_api).with("A long sear").returns(embedding)
+    DB.expects(:query).returns([])
+
+    expect(embedding_process.semantic_search("A long search query")).to eq([])
+  end
 end


### PR DESCRIPTION
Previously, provider model selectors omitted Claude Fable 5.1, Gemini 3.8 Flash, and current embedding and image models while retaining retired preview and image choices.

This change refreshes Anthropic, Google Gemini, and OpenAI model selections with current non-snapshot models, requests 1,536-dimensional OpenAI large embeddings, and bumps the plugin version to 3.0.1.