### PR TITLE
FEATURE: Add GPT Image 2.5 model choices

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -950,6 +950,8 @@ plugins:
     type: enum
     default: gpt-image-2
     choices:
+      - gpt-image-2.5-sunburst
+      - gpt-image-2.5-flare
       - gpt-image-2
       - gpt-image-1.5
       - gpt-image-1-mini

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-chatbot
 # about: a plugin that allows you to have a conversation with a configurable chatbot in Chat, Topics and Private Messages
-# version: 3.0.1
+# version: 3.0.2
 # authors: merefield
 # url: https://github.com/merefield/discourse-chatbot
 

--- a/spec/lib/site_setting_dependencies_spec.rb
+++ b/spec/lib/site_setting_dependencies_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe SiteSetting do
       %w[text-embedding-ada-002 text-embedding-3-small text-embedding-3-large],
     )
     expect(model_choices.call(:chatbot_support_picture_creation_model)).to eq(
-      %w[gpt-image-2 gpt-image-1.5 gpt-image-1-mini],
+      %w[gpt-image-2.5-sunburst gpt-image-2.5-flare gpt-image-2 gpt-image-1.5 gpt-image-1-mini],
     )
     expect(model_choices.call(:chatbot_anthropic_model_high_trust)).to eq(
       %w[claude-fable-5-1 claude-fable-5 claude-opus-5 claude-sonnet-5 claude-haiku-4-5],


### PR DESCRIPTION
Previously, the OpenAI image model selection did not offer GPT Image 2.5 Sunburst or Flare.

This change adds both [documented image models](https://developers.openai.com/api/docs/guides/image-generation) for painting and editing while retaining the existing default and older choices.
